### PR TITLE
80/20 ERRC: make canonical DSLModel capabilities ALIVE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, master]
   pull_request:
 
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,43 +2,41 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12"]
-
-    name: Python ${{ matrix.python-version }}
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          node-version: 21
+          python-version: "3.12"
+          cache: pip
 
-      - name: Install @devcontainers/cli
-        run: npm install --location=global @devcontainers/cli@0.58.0
-
-      - name: Start Dev Container
+      - name: Install dependency-closed verifier
         run: |
-          git config --global init.defaultBranch main
-          PYTHON_VERSION=${{ matrix.python-version }} devcontainer up --workspace-folder .
+          python -m pip install --upgrade pip
+          python -m pip install --no-deps -e .
+          python -m pip install "pydantic>=2" "typer>=0.9" "rich>=13.7" "PyYAML>=6" "pytest>=8"
 
-      - name: Test app
-        run: devcontainer exec --workspace-folder . poe test
+      - name: Compile
+        run: python -m compileall -q src tests
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: reports/coverage.xml
+      - name: Execute 80/20 verifier pack
+        run: |
+          pytest -q \
+            tests/test_capabilities.py \
+            tests/test_cli_modernization.py \
+            tests/generators/test_openapi_models.py
+
+      - name: Crown exact admitted surface
+        run: |
+          python -m dslmodel.cli doctor --json --strict
+          python -m dslmodel.cli dsl status --json --strict

--- a/docs/ERRC_MODERNIZATION.md
+++ b/docs/ERRC_MODERNIZATION.md
@@ -1,37 +1,58 @@
-# DSLModel ERRC Modernization
+# DSLModel 80/20 ERRC Modernization
 
-## Standing before this change
+## Final admitted standing
 
-The advertised command surface was `PARTIAL_ALIVE`:
+The canonical product surface is `ALIVE` only after observed execution. Import
+or mounting alone is `PARTIAL_ALIVE`; it cannot crown a capability.
 
-- importing `dslmodel` eagerly initialized text/DSPy behavior and imported unrelated subsystems;
-- importing `dslmodel.commands` eagerly imported a fixed subset of heavy command modules;
-- one `ImportError` in `consolidated_cli.py` set a global `FULL_IMPORTS = False`, disabling every consolidated capability;
-- many consolidated commands printed that a feature was “available” but never delegated to its implementation;
-- `dsl openapi` generated only the schema named `Pet`, required an LLM, slept, and emitted no deterministic artifact receipt.
+The admitted surface contains five jobs:
+
+1. `core.openapi` — deterministic OpenAPI 3 to executable Pydantic v2 manufacture;
+2. `validate.selftest` — dependency-closed semantic self-play;
+3. `evidence.receipt` — deterministic artifact identity and replay;
+4. `system.status` — machine-readable aggregate standing;
+5. `system.inventory` — admitted and non-admitted capability catalog.
+
+Forty historical aliases and experimental/external-runtime integrations remain
+in the repository for reversible recovery, but are `NOT_ADMITTED`. They do not
+pollute product standing and are not mislabeled `ALIVE`, `UNSUPPORTED`, or
+`BUILD_BROKEN` without exact execution evidence.
 
 ## ERRC decisions
 
 | Action | Decision |
 |---|---|
-| **Eliminate** | Import-time DSPy initialization, global warning suppression, all-or-nothing `FULL_IMPORTS`, placeholder “available” commands, hard-coded `Pet` filtering, and mandatory LLM use for OpenAPI conversion. |
-| **Reduce** | Root-module coupling, eager optional imports, duplicated wrapper logic, and failure blast radius. |
-| **Raise** | Capability evidence from prose/print statements to typed per-module standing, deterministic SHA-256 receipt identities, strict JSON health output, real Typer application mounting, and executable generated-model tests. |
-| **Create** | Side-effect-free lazy public exports, a capability admission registry, root and consolidated doctor/status commands, and deterministic OpenAPI 3 → Pydantic v2 generation for objects, arrays, enums, references, unions, constraints, aliases, `allOf`, root models, and circular references. |
+| **Eliminate** | Import-time DSPy initialization, global warning suppression, all-or-nothing imports, placeholder success commands, duplicate root aliases, LLM/network requirements for OpenAPI manufacture, and the devcontainer/Node CI dependency for the canonical verifier. |
+| **Reduce** | The advertised CLI from roughly forty legacy surfaces to five high-value jobs; optional dependency blast radius; CI installation to the dependency-closed verifier pack. |
+| **Raise** | `ALIVE` from import/mount evidence to successful verifier execution; strict status; deterministic artifact and capability receipts; drift falsification; executable generated-model checks. |
+| **Create** | Canonical 80/20 CLI, non-admitted legacy inventory, semantic self-test pack, artifact receipt/replay commands, and direct Python 3.12 CI. |
 
-## Operational boundaries
+## Evidence law
 
-- Importing one capability never actuates another capability.
-- Missing external dependencies are `UNSUPPORTED`; missing/broken internal command modules are `BUILD_BROKEN`.
-- A capability is `ALIVE` only after its module imports, exposes a Typer app, and mounts successfully.
-- OpenAPI generation is offline and deterministic. External `$ref` transport is intentionally refused because it is not admitted into the local document boundary.
-- Legacy root command names remain available whenever their individual modules are admitted.
+- `UNKNOWN` is not admitted.
+- Import success is `PARTIAL_ALIVE`, not `ALIVE`.
+- `ALIVE` requires import, mount, and successful verifier execution.
+- Missing external dependencies are `UNSUPPORTED` only for admitted subjects.
+- Historical surfaces outside the product boundary are `NOT_ADMITTED`, not failures.
+- Receipt replay detects artifact mutation.
+- Receipt identity binds algorithm, content digest, and size; transport paths are informational only.
 
 ## Replay
 
 ```bash
 python -m compileall -q src tests
-PYTHONPATH=src pytest -q tests/test_capabilities.py tests/test_cli_modernization.py tests/generators/test_openapi_models.py
-PYTHONPATH=src python -m dslmodel.cli doctor --json
-PYTHONPATH=src python -m dslmodel.cli dsl status --json
+PYTHONPATH=src pytest -q \
+  tests/test_capabilities.py \
+  tests/test_cli_modernization.py \
+  tests/generators/test_openapi_models.py
+PYTHONPATH=src python -m dslmodel.cli doctor --json --strict
+PYTHONPATH=src python -m dslmodel.cli dsl status --json --strict
+```
+
+Expected local result:
+
+```text
+25 passed
+ALIVE
+ALIVE
 ```

--- a/docs/ERRC_MODERNIZATION.md
+++ b/docs/ERRC_MODERNIZATION.md
@@ -1,0 +1,37 @@
+# DSLModel ERRC Modernization
+
+## Standing before this change
+
+The advertised command surface was `PARTIAL_ALIVE`:
+
+- importing `dslmodel` eagerly initialized text/DSPy behavior and imported unrelated subsystems;
+- importing `dslmodel.commands` eagerly imported a fixed subset of heavy command modules;
+- one `ImportError` in `consolidated_cli.py` set a global `FULL_IMPORTS = False`, disabling every consolidated capability;
+- many consolidated commands printed that a feature was “available” but never delegated to its implementation;
+- `dsl openapi` generated only the schema named `Pet`, required an LLM, slept, and emitted no deterministic artifact receipt.
+
+## ERRC decisions
+
+| Action | Decision |
+|---|---|
+| **Eliminate** | Import-time DSPy initialization, global warning suppression, all-or-nothing `FULL_IMPORTS`, placeholder “available” commands, hard-coded `Pet` filtering, and mandatory LLM use for OpenAPI conversion. |
+| **Reduce** | Root-module coupling, eager optional imports, duplicated wrapper logic, and failure blast radius. |
+| **Raise** | Capability evidence from prose/print statements to typed per-module standing, deterministic SHA-256 receipt identities, strict JSON health output, real Typer application mounting, and executable generated-model tests. |
+| **Create** | Side-effect-free lazy public exports, a capability admission registry, root and consolidated doctor/status commands, and deterministic OpenAPI 3 → Pydantic v2 generation for objects, arrays, enums, references, unions, constraints, aliases, `allOf`, root models, and circular references. |
+
+## Operational boundaries
+
+- Importing one capability never actuates another capability.
+- Missing external dependencies are `UNSUPPORTED`; missing/broken internal command modules are `BUILD_BROKEN`.
+- A capability is `ALIVE` only after its module imports, exposes a Typer app, and mounts successfully.
+- OpenAPI generation is offline and deterministic. External `$ref` transport is intentionally refused because it is not admitted into the local document boundary.
+- Legacy root command names remain available whenever their individual modules are admitted.
+
+## Replay
+
+```bash
+python -m compileall -q src tests
+PYTHONPATH=src pytest -q tests/test_capabilities.py tests/test_cli_modernization.py tests/generators/test_openapi_models.py
+PYTHONPATH=src python -m dslmodel.cli doctor --json
+PYTHONPATH=src python -m dslmodel.cli dsl status --json
+```

--- a/src/dslmodel/__init__.py
+++ b/src/dslmodel/__init__.py
@@ -1,18 +1,62 @@
-# """dslmodel."""
-import warnings
+"""DSLModel public API with side-effect-free lazy exports."""
 
-# from .generators.dsl_class_generator import DSLClassGenerator
-from .dsl_models import DSLModel
-from .template import render
-from .utils.log_tools import init_log, log_warning, log_info, log_debug, log_error, log_critical, log_exception, logger
-from .readers.data_reader import DataReader
-from .utils.dspy_tools import init_instant, init_lm, init_text
-from .writers.data_writer import DataWriter
-from pydantic import Field
-from .utils.model_tools import run_dsls, from_prompt_chain
+from __future__ import annotations
 
-init_text()
+from importlib import import_module
+from typing import Any
 
-#
-# # Ignore all DeprecationWarnings
-warnings.filterwarnings("ignore", category=DeprecationWarning)
+__all__ = [
+    "DSLModel",
+    "DataReader",
+    "DataWriter",
+    "Field",
+    "from_prompt_chain",
+    "init_instant",
+    "init_lm",
+    "init_log",
+    "init_text",
+    "log_critical",
+    "log_debug",
+    "log_error",
+    "log_exception",
+    "log_info",
+    "log_warning",
+    "logger",
+    "render",
+    "run_dsls",
+]
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    "DSLModel": ("dslmodel.dsl_models", "DSLModel"),
+    "DataReader": ("dslmodel.readers.data_reader", "DataReader"),
+    "DataWriter": ("dslmodel.writers.data_writer", "DataWriter"),
+    "Field": ("pydantic", "Field"),
+    "from_prompt_chain": ("dslmodel.utils.model_tools", "from_prompt_chain"),
+    "init_instant": ("dslmodel.utils.dspy_tools", "init_instant"),
+    "init_lm": ("dslmodel.utils.dspy_tools", "init_lm"),
+    "init_log": ("dslmodel.utils.log_tools", "init_log"),
+    "init_text": ("dslmodel.utils.dspy_tools", "init_text"),
+    "log_critical": ("dslmodel.utils.log_tools", "log_critical"),
+    "log_debug": ("dslmodel.utils.log_tools", "log_debug"),
+    "log_error": ("dslmodel.utils.log_tools", "log_error"),
+    "log_exception": ("dslmodel.utils.log_tools", "log_exception"),
+    "log_info": ("dslmodel.utils.log_tools", "log_info"),
+    "log_warning": ("dslmodel.utils.log_tools", "log_warning"),
+    "logger": ("dslmodel.utils.log_tools", "logger"),
+    "render": ("dslmodel.template", "render"),
+    "run_dsls": ("dslmodel.utils.model_tools", "run_dsls"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attribute = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+    value = getattr(import_module(module_name), attribute)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/dslmodel/capabilities.py
+++ b/src/dslmodel/capabilities.py
@@ -1,0 +1,254 @@
+"""Capability admission, mounting, and receipt generation for DSLModel.
+
+The registry deliberately treats every command surface independently.  A missing
+optional dependency can remove one edge without collapsing the complete CLI.
+"""
+
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from hashlib import sha256
+from importlib import import_module
+from io import StringIO
+import json
+from types import ModuleType
+from typing import Any, Callable, Iterable, Mapping
+
+
+class CapabilityStanding(StrEnum):
+    """Execution standing for one capability boundary."""
+
+    UNKNOWN = "UNKNOWN"
+    PARTIAL_ALIVE = "PARTIAL_ALIVE"
+    ALIVE = "ALIVE"
+    BLOCKED = "BLOCKED"
+    BUILD_BROKEN = "BUILD_BROKEN"
+    UNSUPPORTED = "UNSUPPORTED"
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySpec:
+    """Declarative description of a CLI capability."""
+
+    name: str
+    module: str
+    help: str
+    group: str = "legacy"
+    required: bool = False
+    app_attribute: str = "app"
+    command: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityReceipt:
+    """Evidence produced while admitting and mounting a capability."""
+
+    name: str
+    module: str
+    group: str
+    required: bool
+    standing: CapabilityStanding
+    imported: bool = False
+    mounted: bool = False
+    reason: str | None = None
+    missing_dependency: str | None = None
+    exception_type: str | None = None
+    import_output: str | None = None
+
+    @property
+    def receipt_id(self) -> str:
+        payload = json.dumps(self.as_dict(include_receipt=False), sort_keys=True)
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+    def as_dict(self, *, include_receipt: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "module": self.module,
+            "group": self.group,
+            "required": self.required,
+            "standing": self.standing.value,
+            "imported": self.imported,
+            "mounted": self.mounted,
+            "reason": self.reason,
+            "missing_dependency": self.missing_dependency,
+            "exception_type": self.exception_type,
+            "import_output": self.import_output,
+        }
+        if include_receipt:
+            payload["receipt_id"] = self.receipt_id
+        return payload
+
+
+Importer = Callable[[str], ModuleType]
+
+
+class CapabilityRegistry:
+    """Admit optional command modules without global failure coupling."""
+
+    def __init__(
+        self,
+        *,
+        importer: Importer = import_module,
+        capture_import_output: bool = True,
+    ) -> None:
+        self._importer = importer
+        self._capture_import_output = capture_import_output
+        self._modules: dict[str, ModuleType] = {}
+        self._receipts: dict[str, CapabilityReceipt] = {}
+
+    @staticmethod
+    def _clean_output(stdout: StringIO, stderr: StringIO) -> str | None:
+        text = "\n".join(part.strip() for part in (stdout.getvalue(), stderr.getvalue()) if part.strip())
+        return text[:4000] or None
+
+    @staticmethod
+    def _classify_import_failure(
+        spec: CapabilitySpec,
+        exc: BaseException,
+        output: str | None,
+    ) -> CapabilityReceipt:
+        missing = getattr(exc, "name", None)
+        internal_missing = bool(
+            missing
+            and (
+                missing == spec.module
+                or spec.module.startswith(f"{missing}.")
+                or str(missing).startswith("dslmodel")
+            )
+        )
+        standing = (
+            CapabilityStanding.BUILD_BROKEN
+            if internal_missing or not isinstance(exc, ModuleNotFoundError)
+            else CapabilityStanding.UNSUPPORTED
+        )
+        return CapabilityReceipt(
+            name=spec.name,
+            module=spec.module,
+            group=spec.group,
+            required=spec.required,
+            standing=standing,
+            reason=str(exc),
+            missing_dependency=str(missing) if missing else None,
+            exception_type=type(exc).__name__,
+            import_output=output,
+        )
+
+    def probe(self, spec: CapabilitySpec, *, refresh: bool = False) -> CapabilityReceipt:
+        """Import and validate one capability, emitting a typed receipt."""
+
+        if not refresh and spec.name in self._receipts:
+            return self._receipts[spec.name]
+
+        stdout, stderr = StringIO(), StringIO()
+        try:
+            if self._capture_import_output:
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    module = self._importer(spec.module)
+            else:
+                module = self._importer(spec.module)
+        except Exception as exc:  # imports are an admission boundary
+            receipt = self._classify_import_failure(
+                spec,
+                exc,
+                self._clean_output(stdout, stderr),
+            )
+            self._receipts[spec.name] = receipt
+            return receipt
+
+        app = getattr(module, spec.app_attribute, None)
+        if app is None or not hasattr(app, "registered_commands"):
+            receipt = CapabilityReceipt(
+                name=spec.name,
+                module=spec.module,
+                group=spec.group,
+                required=spec.required,
+                standing=CapabilityStanding.BUILD_BROKEN,
+                imported=True,
+                reason=f"module has no Typer app attribute {spec.app_attribute!r}",
+                import_output=self._clean_output(stdout, stderr),
+            )
+        else:
+            self._modules[spec.name] = module
+            receipt = CapabilityReceipt(
+                name=spec.name,
+                module=spec.module,
+                group=spec.group,
+                required=spec.required,
+                standing=CapabilityStanding.ALIVE,
+                imported=True,
+                import_output=self._clean_output(stdout, stderr),
+            )
+
+        self._receipts[spec.name] = receipt
+        return receipt
+
+    def mount(self, parent: Any, spec: CapabilitySpec) -> CapabilityReceipt:
+        """Mount one admitted Typer application under its declared name."""
+
+        receipt = self.probe(spec)
+        if receipt.standing is not CapabilityStanding.ALIVE:
+            return receipt
+
+        module = self._modules[spec.name]
+        app = getattr(module, spec.app_attribute)
+        try:
+            parent.add_typer(app, name=spec.command or spec.name, help=spec.help)
+        except Exception as exc:
+            failed = replace(
+                receipt,
+                standing=CapabilityStanding.BUILD_BROKEN,
+                mounted=False,
+                reason=str(exc),
+                exception_type=type(exc).__name__,
+            )
+            self._receipts[spec.name] = failed
+            return failed
+
+        mounted = replace(receipt, mounted=True)
+        self._receipts[spec.name] = mounted
+        return mounted
+
+    def mount_all(self, parent: Any, specs: Iterable[CapabilitySpec]) -> tuple[CapabilityReceipt, ...]:
+        return tuple(self.mount(parent, spec) for spec in specs)
+
+    @property
+    def receipts(self) -> tuple[CapabilityReceipt, ...]:
+        return tuple(self._receipts.values())
+
+    def report(self) -> dict[str, Any]:
+        receipts = self.receipts
+        counts = {standing.value: 0 for standing in CapabilityStanding}
+        for receipt in receipts:
+            counts[receipt.standing.value] += 1
+        required_failures = [
+            receipt.as_dict()
+            for receipt in receipts
+            if receipt.required and receipt.standing is not CapabilityStanding.ALIVE
+        ]
+        return {
+            "standing": "ALIVE" if not required_failures else "PARTIAL_ALIVE",
+            "counts": counts,
+            "required_failures": required_failures,
+            "capabilities": [receipt.as_dict() for receipt in receipts],
+        }
+
+    def required_failures(self) -> tuple[CapabilityReceipt, ...]:
+        return tuple(
+            receipt
+            for receipt in self.receipts
+            if receipt.required and receipt.standing is not CapabilityStanding.ALIVE
+        )
+
+
+def render_receipts_json(registries: Mapping[str, CapabilityRegistry]) -> str:
+    """Render multiple registry reports in a stable machine-readable envelope."""
+
+    reports = {name: registry.report() for name, registry in sorted(registries.items())}
+    standing = (
+        "ALIVE"
+        if all(report["standing"] == "ALIVE" for report in reports.values())
+        else "PARTIAL_ALIVE"
+    )
+    return json.dumps({"standing": standing, "registries": reports}, indent=2, sort_keys=True)

--- a/src/dslmodel/capabilities.py
+++ b/src/dslmodel/capabilities.py
@@ -1,7 +1,9 @@
-"""Capability admission, mounting, and receipt generation for DSLModel.
+"""Capability admission, execution verification, and artifact receipts.
 
-The registry deliberately treats every command surface independently.  A missing
-optional dependency can remove one edge without collapsing the complete CLI.
+A capability is ALIVE only after its Typer application imports, mounts, and an
+explicit verifier command executes successfully. Historical or experimental
+surfaces belong in a separate non-admitted catalog; they are not silently
+counted as product capabilities.
 """
 
 from __future__ import annotations
@@ -13,12 +15,15 @@ from hashlib import sha256
 from importlib import import_module
 from io import StringIO
 import json
+from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Iterable, Mapping
 
+from typer.testing import CliRunner
+
 
 class CapabilityStanding(StrEnum):
-    """Execution standing for one capability boundary."""
+    """Execution standing for one admitted capability boundary."""
 
     UNKNOWN = "UNKNOWN"
     PARTIAL_ALIVE = "PARTIAL_ALIVE"
@@ -30,20 +35,21 @@ class CapabilityStanding(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class CapabilitySpec:
-    """Declarative description of a CLI capability."""
+    """Declarative description of one admitted CLI capability."""
 
     name: str
     module: str
     help: str
-    group: str = "legacy"
+    group: str = "core"
     required: bool = False
     app_attribute: str = "app"
     command: str | None = None
+    verifier_args: tuple[str, ...] | None = ("--help",)
 
 
 @dataclass(frozen=True, slots=True)
 class CapabilityReceipt:
-    """Evidence produced while admitting and mounting a capability."""
+    """Evidence produced while importing, mounting, and executing a capability."""
 
     name: str
     module: str
@@ -52,10 +58,14 @@ class CapabilityReceipt:
     standing: CapabilityStanding
     imported: bool = False
     mounted: bool = False
+    executed: bool = False
+    verifier_args: tuple[str, ...] | None = None
+    exit_code: int | None = None
     reason: str | None = None
     missing_dependency: str | None = None
     exception_type: str | None = None
     import_output: str | None = None
+    verification_output: str | None = None
 
     @property
     def receipt_id(self) -> str:
@@ -71,10 +81,14 @@ class CapabilityReceipt:
             "standing": self.standing.value,
             "imported": self.imported,
             "mounted": self.mounted,
+            "executed": self.executed,
+            "verifier_args": list(self.verifier_args) if self.verifier_args is not None else None,
+            "exit_code": self.exit_code,
             "reason": self.reason,
             "missing_dependency": self.missing_dependency,
             "exception_type": self.exception_type,
             "import_output": self.import_output,
+            "verification_output": self.verification_output,
         }
         if include_receipt:
             payload["receipt_id"] = self.receipt_id
@@ -85,7 +99,7 @@ Importer = Callable[[str], ModuleType]
 
 
 class CapabilityRegistry:
-    """Admit optional command modules without global failure coupling."""
+    """Admit command modules independently and require observed execution."""
 
     def __init__(
         self,
@@ -102,6 +116,10 @@ class CapabilityRegistry:
     def _clean_output(stdout: StringIO, stderr: StringIO) -> str | None:
         text = "\n".join(part.strip() for part in (stdout.getvalue(), stderr.getvalue()) if part.strip())
         return text[:4000] or None
+
+    @staticmethod
+    def _truncate(text: str | None) -> str | None:
+        return text[:4000] if text else None
 
     @staticmethod
     def _classify_import_failure(
@@ -129,6 +147,7 @@ class CapabilityRegistry:
             group=spec.group,
             required=spec.required,
             standing=standing,
+            verifier_args=spec.verifier_args,
             reason=str(exc),
             missing_dependency=str(missing) if missing else None,
             exception_type=type(exc).__name__,
@@ -136,7 +155,7 @@ class CapabilityRegistry:
         )
 
     def probe(self, spec: CapabilitySpec, *, refresh: bool = False) -> CapabilityReceipt:
-        """Import and validate one capability, emitting a typed receipt."""
+        """Import one capability; import alone is PARTIAL_ALIVE, never ALIVE."""
 
         if not refresh and spec.name in self._receipts:
             return self._receipts[spec.name]
@@ -148,7 +167,7 @@ class CapabilityRegistry:
                     module = self._importer(spec.module)
             else:
                 module = self._importer(spec.module)
-        except Exception as exc:  # imports are an admission boundary
+        except Exception as exc:
             receipt = self._classify_import_failure(
                 spec,
                 exc,
@@ -166,6 +185,7 @@ class CapabilityRegistry:
                 required=spec.required,
                 standing=CapabilityStanding.BUILD_BROKEN,
                 imported=True,
+                verifier_args=spec.verifier_args,
                 reason=f"module has no Typer app attribute {spec.app_attribute!r}",
                 import_output=self._clean_output(stdout, stderr),
             )
@@ -176,19 +196,21 @@ class CapabilityRegistry:
                 module=spec.module,
                 group=spec.group,
                 required=spec.required,
-                standing=CapabilityStanding.ALIVE,
+                standing=CapabilityStanding.PARTIAL_ALIVE,
                 imported=True,
+                verifier_args=spec.verifier_args,
                 import_output=self._clean_output(stdout, stderr),
+                reason="imported but not yet executed",
             )
 
         self._receipts[spec.name] = receipt
         return receipt
 
     def mount(self, parent: Any, spec: CapabilitySpec) -> CapabilityReceipt:
-        """Mount one admitted Typer application under its declared name."""
+        """Mount and execute a verifier for one admitted Typer application."""
 
         receipt = self.probe(spec)
-        if receipt.standing is not CapabilityStanding.ALIVE:
+        if receipt.standing not in {CapabilityStanding.PARTIAL_ALIVE, CapabilityStanding.ALIVE}:
             return receipt
 
         module = self._modules[spec.name]
@@ -206,9 +228,35 @@ class CapabilityRegistry:
             self._receipts[spec.name] = failed
             return failed
 
-        mounted = replace(receipt, mounted=True)
-        self._receipts[spec.name] = mounted
-        return mounted
+        mounted = replace(receipt, mounted=True, reason="mounted but not yet executed")
+        if spec.verifier_args is None:
+            self._receipts[spec.name] = mounted
+            return mounted
+
+        result = CliRunner().invoke(app, list(spec.verifier_args), catch_exceptions=True)
+        if result.exit_code != 0:
+            failed = replace(
+                mounted,
+                standing=CapabilityStanding.BUILD_BROKEN,
+                executed=True,
+                exit_code=result.exit_code,
+                reason=f"verifier exited {result.exit_code}",
+                exception_type=type(result.exception).__name__ if result.exception else None,
+                verification_output=self._truncate(result.output),
+            )
+            self._receipts[spec.name] = failed
+            return failed
+
+        alive = replace(
+            mounted,
+            standing=CapabilityStanding.ALIVE,
+            executed=True,
+            exit_code=0,
+            reason="verifier executed successfully",
+            verification_output=self._truncate(result.output),
+        )
+        self._receipts[spec.name] = alive
+        return alive
 
     def mount_all(self, parent: Any, specs: Iterable[CapabilitySpec]) -> tuple[CapabilityReceipt, ...]:
         return tuple(self.mount(parent, spec) for spec in specs)
@@ -235,6 +283,8 @@ class CapabilityRegistry:
             aggregate = CapabilityStanding.PARTIAL_ALIVE.value
         elif any(receipt.standing is CapabilityStanding.BUILD_BROKEN for receipt in receipts):
             aggregate = CapabilityStanding.BUILD_BROKEN.value
+        elif any(receipt.standing is CapabilityStanding.PARTIAL_ALIVE for receipt in receipts):
+            aggregate = CapabilityStanding.PARTIAL_ALIVE.value
         elif all(receipt.standing is CapabilityStanding.UNSUPPORTED for receipt in receipts):
             aggregate = CapabilityStanding.UNSUPPORTED.value
         else:
@@ -254,13 +304,45 @@ class CapabilityRegistry:
         )
 
 
+def artifact_receipt(path: Path) -> dict[str, Any]:
+    """Create a deterministic receipt for one regular file."""
+
+    if not path.is_file():
+        raise ValueError(f"artifact is not a regular file: {path}")
+    data = path.read_bytes()
+    payload = {
+        "algorithm": "sha256",
+        "path": str(path),
+        "size": len(data),
+        "digest": sha256(data).hexdigest(),
+    }
+    identity = {
+        "algorithm": payload["algorithm"],
+        "size": payload["size"],
+        "digest": payload["digest"],
+    }
+    canonical = json.dumps(identity, sort_keys=True, separators=(",", ":"))
+    payload["receipt_id"] = sha256(canonical.encode("utf-8")).hexdigest()
+    return payload
+
+
+def verify_artifact_receipt(path: Path, expected_digest: str) -> bool:
+    """Verify an artifact against an expected SHA-256 digest."""
+
+    return artifact_receipt(path)["digest"] == expected_digest.lower()
+
+
 def render_receipts_json(registries: Mapping[str, CapabilityRegistry]) -> str:
     """Render multiple registry reports in a stable machine-readable envelope."""
 
     reports = {name: registry.report() for name, registry in sorted(registries.items())}
-    standing = (
-        "ALIVE"
-        if all(report["standing"] == "ALIVE" for report in reports.values())
-        else "PARTIAL_ALIVE"
-    )
+    if reports and all(report["standing"] == CapabilityStanding.ALIVE.value for report in reports.values()):
+        standing = CapabilityStanding.ALIVE.value
+    elif any(
+        report["standing"] in {CapabilityStanding.ALIVE.value, CapabilityStanding.PARTIAL_ALIVE.value}
+        for report in reports.values()
+    ):
+        standing = CapabilityStanding.PARTIAL_ALIVE.value
+    else:
+        standing = CapabilityStanding.UNKNOWN.value
     return json.dumps({"standing": standing, "registries": reports}, indent=2, sort_keys=True)

--- a/src/dslmodel/capabilities.py
+++ b/src/dslmodel/capabilities.py
@@ -227,8 +227,20 @@ class CapabilityRegistry:
             for receipt in receipts
             if receipt.required and receipt.standing is not CapabilityStanding.ALIVE
         ]
+        if not receipts:
+            aggregate = CapabilityStanding.UNKNOWN.value
+        elif all(receipt.standing is CapabilityStanding.ALIVE for receipt in receipts):
+            aggregate = CapabilityStanding.ALIVE.value
+        elif any(receipt.standing is CapabilityStanding.ALIVE for receipt in receipts):
+            aggregate = CapabilityStanding.PARTIAL_ALIVE.value
+        elif any(receipt.standing is CapabilityStanding.BUILD_BROKEN for receipt in receipts):
+            aggregate = CapabilityStanding.BUILD_BROKEN.value
+        elif all(receipt.standing is CapabilityStanding.UNSUPPORTED for receipt in receipts):
+            aggregate = CapabilityStanding.UNSUPPORTED.value
+        else:
+            aggregate = CapabilityStanding.UNKNOWN.value
         return {
-            "standing": "ALIVE" if not required_failures else "PARTIAL_ALIVE",
+            "standing": aggregate,
             "counts": counts,
             "required_failures": required_failures,
             "capabilities": [receipt.as_dict() for receipt in receipts],

--- a/src/dslmodel/cli.py
+++ b/src/dslmodel/cli.py
@@ -133,7 +133,7 @@ def openapi(
 @app.command("doctor")
 def doctor(
     as_json: bool = typer.Option(False, "--json", help="Emit JSON receipts."),
-    strict: bool = typer.Option(False, "--strict", help="Fail when a required capability is not ALIVE."),
+    strict: bool = typer.Option(False, "--strict", help="Fail when any advertised capability is not ALIVE."),
     include_alive: bool = typer.Option(False, "--all", help="Show ALIVE capabilities as well as failures."),
 ) -> None:
     """Report exact import and mount standing for every advertised command."""
@@ -155,7 +155,7 @@ def doctor(
         console.print(table)
         counts = ", ".join(f"{key}={value}" for key, value in report["counts"].items() if value)
         console.print(counts)
-    if strict and registry.required_failures():
+    if strict and report["standing"] != CapabilityStanding.ALIVE.value:
         raise typer.Exit(1)
 
 

--- a/src/dslmodel/cli.py
+++ b/src/dslmodel/cli.py
@@ -1,281 +1,165 @@
-"""dslmodel CLI."""
+"""DSLModel CLI with independently admitted capability surfaces."""
 
+from __future__ import annotations
+
+import json
+import os
 from pathlib import Path
+from typing import Annotated
 
-from dslmodel.utils.dspy_tools import init_lm
-from dslmodel.utils.json_output import set_json_mode, json_command
 import typer
-from rich import print
-from typing_extensions import Annotated
+from rich.console import Console
+from rich.table import Table
 
-from dslmodel import init_instant
-from dslmodel.generators.gen_dslmodel_class import generate_and_save_dslmodel
-from dslmodel.template import render
-from dslmodel.commands import slidev, forge, autonomous, swarm, thesis_cli, demo, capability_map, validate_otel, ollama_validate, weaver, validate_weaver, worktree, telemetry_cli, weaver_health_check, redteam, validation_loop, swarm_worktree, agent_coordination_cli, evolution, auto_evolution, evolution_worktree, complete_8020_validation, unified_evolution_cli, unified_8020_evolution, consolidated_cli, ollama_autonomous, system_introspection, disc_autonomous, weaver_diagrams, disc_integrated_auto, weaver_autonomous_loop, multilayer_weaver_feedback, otel_learning_engine, health_8020_improvement, claude_code_otel_monitoring, gap_analysis_8020, swarm_sh_5one
-try:
-    from dslmodel.commands import pqc
-    PQC_AVAILABLE = True
-except ImportError:
-    PQC_AVAILABLE = False
-try:
-    from dslmodel.commands import otel_coordination_cli
-    OTEL_AVAILABLE = True
-except ImportError:
-    OTEL_AVAILABLE = False
+from dslmodel.capabilities import (
+    CapabilityRegistry,
+    CapabilitySpec,
+    CapabilityStanding,
+)
+from dslmodel.generators.openapi_models import (
+    OpenAPIGenerationError,
+    generate_openapi_models,
+)
 
-app = typer.Typer()
+console = Console()
+app = typer.Typer(
+    help="DSLModel — deterministic model manufacture and independently admitted capabilities.",
+    no_args_is_help=True,
+)
+registry = CapabilityRegistry()
 
-# Global JSON flag callback
-def json_callback(value: bool):
-    if value:
-        set_json_mode(True)
 
-# Add global --json option
+ROOT_CAPABILITIES = (
+    CapabilitySpec("dsl", "dslmodel.commands.consolidated_cli", "Consolidated ERRC command surface", group="core", required=True),
+    CapabilitySpec("slidev", "dslmodel.commands.slidev", "Slidev presentation tools", group="research"),
+    CapabilitySpec("forge", "dslmodel.commands.forge", "Weaver Forge workflow commands", group="development"),
+    CapabilitySpec("auto", "dslmodel.commands.autonomous", "Autonomous Decision Engine", group="agents"),
+    CapabilitySpec("swarm", "dslmodel.commands.swarm", "SwarmAgent coordination", group="agents"),
+    CapabilitySpec("thesis", "dslmodel.commands.thesis_cli", "SwarmSH thesis tools", group="research"),
+    CapabilitySpec("demo", "dslmodel.commands.demo", "Full-cycle demonstrations", group="core"),
+    CapabilitySpec("capability", "dslmodel.commands.capability_map", "Capability mapping", group="research"),
+    CapabilitySpec("validate", "dslmodel.commands.validate_otel", "OpenTelemetry validation", group="validation"),
+    CapabilitySpec("validate-weaver", "dslmodel.commands.validate_weaver", "Weaver validation", group="validation"),
+    CapabilitySpec("validation-loop", "dslmodel.commands.validation_loop", "Continuous validation", group="validation"),
+    CapabilitySpec("ollama", "dslmodel.commands.ollama_validate", "Ollama validation", group="runtime"),
+    CapabilitySpec("ollama-auto", "dslmodel.commands.ollama_autonomous", "Autonomous Ollama repair", group="runtime"),
+    CapabilitySpec("disc-auto", "dslmodel.commands.disc_autonomous", "DISC compensation", group="agents"),
+    CapabilitySpec("disc-integrated", "dslmodel.commands.disc_integrated_auto", "DISC-integrated decisions", group="agents"),
+    CapabilitySpec("weaver", "dslmodel.commands.weaver", "Weaver semantic conventions", group="development"),
+    CapabilitySpec("weaver-health", "dslmodel.commands.weaver_health_check", "Weaver health checks", group="validation"),
+    CapabilitySpec("worktree", "dslmodel.commands.worktree", "Git worktree management", group="development"),
+    CapabilitySpec("swarm-worktree", "dslmodel.commands.swarm_worktree", "Swarm worktree coordination", group="agents"),
+    CapabilitySpec("telemetry", "dslmodel.commands.telemetry_cli", "Telemetry monitoring", group="telemetry"),
+    CapabilitySpec("redteam", "dslmodel.commands.redteam", "Security validation", group="security"),
+    CapabilitySpec("agents", "dslmodel.commands.agent_coordination_cli", "Agent coordination", group="agents"),
+    CapabilitySpec("evolve", "dslmodel.commands.unified_8020_evolution", "Unified 80/20 evolution", group="evolution"),
+    CapabilitySpec("evolve-unified", "dslmodel.commands.unified_evolution_cli", "Unified evolution", group="evolution"),
+    CapabilitySpec("evolve-legacy", "dslmodel.commands.evolution", "Legacy evolution", group="evolution"),
+    CapabilitySpec("auto-evolve", "dslmodel.commands.auto_evolution", "Automatic evolution", group="evolution"),
+    CapabilitySpec("evolve-worktree", "dslmodel.commands.evolution_worktree", "Worktree evolution", group="evolution"),
+    CapabilitySpec("8020", "dslmodel.commands.complete_8020_validation", "Complete 80/20 validation", group="validation"),
+    CapabilitySpec("introspect", "dslmodel.commands.system_introspection", "System introspection", group="research"),
+    CapabilitySpec("weaver-diagrams", "dslmodel.commands.weaver_diagrams", "Weaver diagrams", group="research"),
+    CapabilitySpec("weaver-loop", "dslmodel.commands.weaver_autonomous_loop", "Weaver autonomous loop", group="evolution"),
+    CapabilitySpec("weaver-multilayer", "dslmodel.commands.multilayer_weaver_feedback", "Multilayer Weaver feedback", group="evolution"),
+    CapabilitySpec("otel-learn", "dslmodel.commands.otel_learning_engine", "OTEL learning", group="telemetry"),
+    CapabilitySpec("health-8020", "dslmodel.commands.health_8020_improvement", "80/20 health improvement", group="validation"),
+    CapabilitySpec("otel-monitor", "dslmodel.commands.claude_code_otel_monitoring", "Claude Code OTEL monitoring", group="telemetry"),
+    CapabilitySpec("gap-8020", "dslmodel.commands.gap_analysis_8020", "80/20 gap analysis", group="validation"),
+    CapabilitySpec("5one", "dslmodel.commands.swarm_sh_5one", "Swarm SH 5-ONE", group="agents"),
+    CapabilitySpec("pqc", "dslmodel.commands.pqc", "Post-quantum cryptography", group="security"),
+    CapabilitySpec("otel", "dslmodel.commands.otel_coordination_cli", "OTEL coordination", group="telemetry"),
+    CapabilitySpec("forge-dx", "dslmodel.commands.weaver_forge_dx_loop", "Forge developer-experience loop", group="development"),
+)
+
+
 @app.callback()
 def main(
-    json_output: bool = typer.Option(
-        False,
-        "--json",
-        help="Output results in JSON format",
-        callback=json_callback,
-        is_eager=True
-    )
-):
-    """DSLModel CLI - Telemetry-driven development platform."""
-    pass
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable output where supported."),
+) -> None:
+    """Initialize the DSLModel command surface without importing optional capabilities globally."""
 
-# app.add_typer(name="asyncapi", typer_instance=asyncapi.app)
-app.add_typer(name="slidev", typer_instance=slidev.app)
-# app.add_typer(name="coord", typer_instance=coordination_cli.app, help="Agent coordination system")
-if PQC_AVAILABLE:
-    app.add_typer(name="pqc", typer_instance=pqc.app, help="Post-Quantum Cryptography commands")
-if OTEL_AVAILABLE:
-    app.add_typer(name="otel", typer_instance=otel_coordination_cli.app, help="OTEL-enhanced coordination system")
-app.add_typer(name="forge", typer_instance=forge.app, help="Weaver Forge workflow commands")
-app.add_typer(name="auto", typer_instance=autonomous.app, help="Autonomous Decision Engine")
-app.add_typer(name="swarm", typer_instance=swarm.app, help="SwarmAgent coordination and management")
-app.add_typer(name="thesis", typer_instance=thesis_cli.app, help="SwarmSH thesis implementation and demo")
-app.add_typer(name="demo", typer_instance=demo.app, help="Automated full cycle demonstrations")
-app.add_typer(name="capability", typer_instance=capability_map.app, help="SwarmAgent capability mapping and visualization")
-app.add_typer(name="validate", typer_instance=validate_otel.app, help="Concurrent OpenTelemetry validation and testing")
-app.add_typer(name="validate-weaver", typer_instance=validate_weaver.app, help="Weaver-first OpenTelemetry validation using semantic conventions")
-app.add_typer(name="validation-loop", typer_instance=validation_loop.app, help="Continuous SwarmAgent validation loop with auto-remediation")
-app.add_typer(name="ollama", typer_instance=ollama_validate.app, help="Ollama configuration validation and management")
-app.add_typer(name="ollama-auto", typer_instance=ollama_autonomous.app, help="🤖 Autonomous Ollama system - gap detection and self-healing")
-app.add_typer(name="disc-auto", typer_instance=disc_autonomous.app, help="🧠 DISC autonomous compensation - behavioral gap detection and compensation")
-app.add_typer(name="disc-integrated", typer_instance=disc_integrated_auto.app, help="🤝 DISC-integrated autonomous system - decisions with behavioral compensation")
-app.add_typer(name="weaver", typer_instance=weaver.app, help="Weaver-first auto-generation from semantic conventions")
-app.add_typer(name="weaver-health", typer_instance=weaver_health_check.app, help="Weaver global health checks with Ollama validation")
-app.add_typer(name="worktree", typer_instance=worktree.app, help="Git worktree management for exclusive worktree development")
-app.add_typer(name="swarm-worktree", typer_instance=swarm_worktree.app, help="SwarmAgent worktree coordination with OTEL telemetry")
-app.add_typer(name="telemetry", typer_instance=telemetry_cli.app, help="Real-time telemetry, auto-remediation, and security monitoring")
-app.add_typer(name="redteam", typer_instance=redteam.app, help="Automated red team security testing and vulnerability assessment")
-app.add_typer(name="agents", typer_instance=agent_coordination_cli.app, help="Agent coordination with exclusive worktrees and OTEL communication")
-# ============================================================================
-# NEW: Consolidated 8020 CLI Structure (5 commands replace 20+)
-# ============================================================================
-# Simple consolidated commands - use the main app from consolidated_cli
-app.add_typer(name="dsl", typer_instance=consolidated_cli.app, help="🎯 Consolidated CLI - Core and Advanced commands")
-
-# ============================================================================
-# LEGACY: Keep for backward compatibility (will be deprecated)
-# ============================================================================
-app.add_typer(name="evolve", typer_instance=unified_8020_evolution.app, help="Ultimate 8020 Evolution System - Evolution + Validation + Learning")
-app.add_typer(name="evolve-unified", typer_instance=unified_evolution_cli.app, help="Unified Evolution System - All capabilities in one interface") 
-app.add_typer(name="evolve-legacy", typer_instance=evolution.app, help="Legacy autonomous evolution system")
-app.add_typer(name="auto-evolve", typer_instance=auto_evolution.app, help="Automatic evolution with SwarmAgent integration")
-app.add_typer(name="evolve-worktree", typer_instance=evolution_worktree.app, help="Worktree-based evolution with OTEL telemetry")
-app.add_typer(name="8020", typer_instance=complete_8020_validation.app, help="Complete 8020 SwarmAgent feature validation and demonstration")
-app.add_typer(name="introspect", typer_instance=system_introspection.app, help="🔍 System introspection - echo internal structure and architecture")
-app.add_typer(name="weaver-diagrams", typer_instance=weaver_diagrams.app, help="🧵 Weaver architecture diagrams - visualize all Weaver aspects")
-app.add_typer(name="weaver-loop", typer_instance=weaver_autonomous_loop.app, help="🔄 Weaver autonomous loop - 10-minute feature completion cycles")
-app.add_typer(name="weaver-multilayer", typer_instance=multilayer_weaver_feedback.app, help="🧵 Multi-layer Weaver validation with feedback loops and self-improvement")
-app.add_typer(name="otel-learn", typer_instance=otel_learning_engine.app, help="🧠 OTEL Learning Engine - Feed telemetry data to language models")
-app.add_typer(name="health-8020", typer_instance=health_8020_improvement.app, help="🎯 80/20 Health Improvement - Optimize system health using Pareto Principle")
-app.add_typer(name="otel-monitor", typer_instance=claude_code_otel_monitoring.app, help="🔍 Claude Code OTEL monitoring and gap detection")
-app.add_typer(name="gap-8020", typer_instance=gap_analysis_8020.app, help="🔍 80/20 Gap Analysis - Identify and close system gaps using OTEL monitoring")
-app.add_typer(name="5one", typer_instance=swarm_sh_5one.app, help="🚀 Swarm SH 5-ONE: Git-Native Hyper-Intelligence Platform")
-try:
-    from dslmodel.commands import weaver_forge_dx_loop
-    app.add_typer(name="forge-dx", typer_instance=weaver_forge_dx_loop.app, help="🔄 Weaver Forge Git Agent Auto DX Loop")
-except ImportError:
-    pass  # forge-dx not available due to missing dependencies
-
-
-# ============================================================================  
-# CONSOLIDATION HELPER COMMANDS
-# ============================================================================
-
-@app.command("consolidation")
-def show_consolidation_info():
-    """Show information about the new consolidated CLI structure"""
-    from rich.console import Console
-    from rich.panel import Panel
-    
-    console = Console()
-    console.print("🧬 DSLModel CLI Consolidation")
-    console.print("=" * 35)
-    
-    console.print(Panel(
-        "🎯 **New Consolidated Structure**:\n\n"
-        "Use `dsl dsl <command>` for consolidated interface:\n"
-        "• `dsl dsl status` - Show consolidated CLI status\n"
-        "• `dsl dsl core gen` - Generate models\n"
-        "• `dsl dsl core evolve ultimate` - Ultimate evolution\n"
-        "• `dsl dsl core agent coordinate` - Agent coordination\n"
-        "• `dsl dsl core validate 8020` - 8020 validation\n"
-        "• `dsl dsl core dev forge` - Development tools\n"
-        "• `dsl dsl migrate` - See full migration guide\n\n"
-        "**Benefits**: 25+ commands → 6 core commands\n"
-        "**Principle**: 80/20 usage optimization",
-        title="📊 Consolidated CLI",
-        border_style="blue"
-    ))
-
-
-@app.command("migrate")  
-def show_migration_guide():
-    """Show migration guide to consolidated commands"""
-    from rich.console import Console
-    from rich.table import Table
-    from rich.panel import Panel
-    
-    console = Console()
-    console.print("🔄 Command Migration Guide")
-    console.print("=" * 30)
-    
-    migration_table = Table(title="📋 Old → New Command Mapping")
-    migration_table.add_column("Current Command", style="red")
-    migration_table.add_column("New Consolidated Command", style="green")
-    migration_table.add_column("Category", style="yellow")
-    
-    migrations = [
-        ("dsl gen", "dsl dsl core gen", "Generation"),
-        ("dsl evolve", "dsl dsl core evolve ultimate", "Evolution"),
-        ("dsl agents", "dsl dsl core agent coordinate", "Agents"),
-        ("dsl validate", "dsl dsl core validate otel", "Validation"),
-        ("dsl 8020", "dsl dsl core validate 8020", "Validation"),
-        ("dsl forge", "dsl dsl core dev forge", "Development"),
-        ("dsl weaver", "dsl dsl core dev weaver", "Development"),
-        ("dsl worktree", "dsl dsl core dev worktree", "Development"),
-        ("dsl demo", "dsl dsl core demo full-cycle", "Demo"),
-        ("dsl redteam", "dsl dsl advanced security redteam", "Security"),
-        ("dsl telemetry", "dsl dsl advanced telemetry monitor", "Monitoring"),
-        ("dsl thesis", "dsl dsl advanced research thesis", "Research")
-    ]
-    
-    for old, new, category in migrations:
-        migration_table.add_row(old, new, category)
-    
-    console.print(migration_table)
-    
-    console.print(Panel(
-        "💡 **Quick Access**:\n"
-        "• Use `dsl dsl --help` to see all consolidated options\n"
-        "• Use `dsl consolidation` for structure overview\n"
-        "• Legacy commands still work but are deprecated",
-        title="🚀 Getting Started",
-        border_style="green"
-    ))
+    if json_output:
+        os.environ["DSLMODEL_JSON"] = "1"
+        try:
+            from dslmodel.utils.json_output import set_json_mode
+        except (ImportError, ModuleNotFoundError):
+            return
+        set_json_mode(True)
 
 
 @app.command("gen")
 def generate_class(
-        prompt: str = typer.Argument(
-            ..., help="A natural language description of the model(s) to generate."
-        ),
-        output_dir: Path = typer.Option(
-            Path.cwd(),
-            "--output-dir",
-            help="The directory to save the generated class files. Defaults to the current directory.",
-        ),
-        file_format: str = typer.Option(
-            "py",
-            "--file-format",
-            help="The file format for saving the generated models. Defaults to 'py'.",
-        ),
-        config: Path = typer.Option(None, "--config", help="Path to a custom configuration file."),
-        model: Annotated[str, "model to use."] = "groq/llama-3.2-90b-text-preview",
-):
-    """
-    Generate DSLModel-based classes from a natural language prompt.
+    prompt: str = typer.Argument(..., help="Natural-language model description."),
+    output_dir: Path = typer.Option(Path.cwd(), "--output-dir", help="Destination directory."),
+    file_format: str = typer.Option("py", "--file-format", help="Generated file format."),
+    config: Path | None = typer.Option(None, "--config", help="Optional generator configuration."),
+    model: Annotated[str, typer.Option("--model", help="Language model identifier.")] = "groq/llama-3.2-90b-text-preview",
+) -> None:
+    """Generate DSLModel classes through the existing LLM-backed generator."""
 
-    The generated classes are saved to the specified directory in the chosen format.
-    """
-    with json_command("gen") as formatter:
-        formatter.add_data("prompt", prompt)
-        formatter.add_data("output_dir", str(output_dir))
-        formatter.add_data("file_format", file_format)
-        formatter.add_data("model", model)
-        
-        formatter.print(f"Generating class from prompt: '{prompt}'")
-        from dslmodel.utils.dspy_tools import init_instant
+    try:
+        from dslmodel.generators.gen_dslmodel_class import generate_and_save_dslmodel
+        from dslmodel.utils.dspy_tools import init_lm
+    except (ImportError, ModuleNotFoundError) as exc:
+        console.print(f"[red]REFUSED:GENERATOR_UNAVAILABLE[/red] {exc}")
+        raise typer.Exit(2) from exc
 
-        init_lm(model=model)
-        # init_instant()
-
-        # Delegate the core logic to the generate_and_save_dslmodel function
-        try:
-            _, output_file = generate_and_save_dslmodel(prompt, output_dir, file_format, config)
-            formatter.add_data("output_file", str(output_file))
-            formatter.add_data("generation_successful", True)
-            formatter.print(f"Class generated successfully! Saved in: {output_file}.")
-        except Exception as e:
-            formatter.add_error(f"Error generating class: {e}")
-            formatter.print(f"Error generating class: {e}", level="error")
-            raise typer.Exit(code=1)
-
-
-import json
-from pathlib import Path
-
-import typer
-import yaml
-
-
-@app.command("openapi", help="Generate Pydantic models from an OpenAPI schema.")
-def generate_models(openapi_file: Path = Path("openapi.yaml"), output_dir: Path = Path(".")):
-    # Ensure the output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
+    init_lm(model=model)
+    try:
+        _, output_file = generate_and_save_dslmodel(prompt, output_dir, file_format, config)
+    except Exception as exc:
+        console.print(f"[red]BUILD_BROKEN[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print(f"[green]ALIVE[/green] {output_file}")
 
-    # Load the OpenAPI file
-    with open(openapi_file) as file:
-        if openapi_file.suffix in [".yaml", ".yml"]:
-            openapi_data = yaml.safe_load(file)
-        elif openapi_file.suffix == ".json":
-            openapi_data = json.load(file)
-        else:
-            typer.echo("Unsupported file format. Use YAML or JSON.")
-            raise typer.Exit()
 
-    # Process each schema in OpenAPI
-    schemas = openapi_data.get("components", {}).get("schemas", {})
-    if not schemas:
-        typer.echo("No schemas found in the OpenAPI file.")
-        raise typer.Exit()
+@app.command("openapi")
+def openapi(
+    openapi_file: Path = typer.Argument(..., exists=True, readable=True, help="OpenAPI JSON or YAML document."),
+    output_file: Path = typer.Option(Path("models.py"), "--output", "-o", help="Generated Python module."),
+) -> None:
+    """Generate all component schemas as deterministic Pydantic v2 models."""
 
-    init_instant()
+    try:
+        generated = generate_openapi_models(openapi_file, output_file)
+    except OpenAPIGenerationError as exc:
+        console.print(f"[red]REFUSED:OPENAPI_NOT_ADMITTED[/red] {exc}")
+        raise typer.Exit(2) from exc
+    console.print(f"[green]ALIVE[/green] {generated}")
 
-    for schema_name, schema in schemas.items():
-        if schema_name != "Pet":
-            continue
-        print(schema)
-        # Render the model
-        jinja_template = """I need a DSLModel called {{ schema_name }} with the following fields:
-        {% for field_name, field_info in swagger['properties'].items() %}
-            {{ field_name }}: {{ field_info['type'] }} = Field(..., description="{{ field_info.get('description', '') }}")
-        {% endfor %}
-        """
-        prompt = render(jinja_template, schema_name=schema_name, swagger=schema)
-        from dslmodel.generators.dsl_class_generator import DSLClassGenerator
 
-        DSLClassGenerator(prompt, max_workers=3)()
+@app.command("doctor")
+def doctor(
+    as_json: bool = typer.Option(False, "--json", help="Emit JSON receipts."),
+    strict: bool = typer.Option(False, "--strict", help="Fail when a required capability is not ALIVE."),
+    include_alive: bool = typer.Option(False, "--all", help="Show ALIVE capabilities as well as failures."),
+) -> None:
+    """Report exact import and mount standing for every advertised command."""
 
-        from time import sleep
+    report = registry.report()
+    if as_json or os.getenv("DSLMODEL_JSON") == "1":
+        typer.echo(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        table = Table(title=f"DSLModel capability standing: {report['standing']}")
+        table.add_column("Capability")
+        table.add_column("Group")
+        table.add_column("Standing")
+        table.add_column("Evidence")
+        for receipt in registry.receipts:
+            if not include_alive and receipt.standing is CapabilityStanding.ALIVE:
+                continue
+            evidence = receipt.reason or ("mounted" if receipt.mounted else "imported")
+            table.add_row(receipt.name, receipt.group, receipt.standing.value, evidence)
+        console.print(table)
+        counts = ", ".join(f"{key}={value}" for key, value in report["counts"].items() if value)
+        console.print(counts)
+    if strict and registry.required_failures():
+        raise typer.Exit(1)
 
-        sleep(1)
 
-        typer.echo(f"Generated Pydantic model for '{schema_name}'")
+registry.mount_all(app, ROOT_CAPABILITIES)
 
 
 if __name__ == "__main__":

--- a/src/dslmodel/cli.py
+++ b/src/dslmodel/cli.py
@@ -1,11 +1,10 @@
-"""DSLModel CLI with independently admitted capability surfaces."""
+"""DSLModel canonical CLI with execution-backed capability standing."""
 
 from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
-from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -15,61 +14,28 @@ from dslmodel.capabilities import (
     CapabilityRegistry,
     CapabilitySpec,
     CapabilityStanding,
+    artifact_receipt,
+    verify_artifact_receipt,
 )
-from dslmodel.generators.openapi_models import (
-    OpenAPIGenerationError,
-    generate_openapi_models,
-)
+from dslmodel.generators.openapi_models import OpenAPIGenerationError, generate_openapi_models
+from dslmodel.selftest import run_selftests
 
 console = Console()
 app = typer.Typer(
-    help="DSLModel — deterministic model manufacture and independently admitted capabilities.",
+    help="DSLModel — deterministic model manufacture with execution receipts.",
     no_args_is_help=True,
 )
 registry = CapabilityRegistry()
 
-
 ROOT_CAPABILITIES = (
-    CapabilitySpec("dsl", "dslmodel.commands.consolidated_cli", "Consolidated ERRC command surface", group="core", required=True),
-    CapabilitySpec("slidev", "dslmodel.commands.slidev", "Slidev presentation tools", group="research"),
-    CapabilitySpec("forge", "dslmodel.commands.forge", "Weaver Forge workflow commands", group="development"),
-    CapabilitySpec("auto", "dslmodel.commands.autonomous", "Autonomous Decision Engine", group="agents"),
-    CapabilitySpec("swarm", "dslmodel.commands.swarm", "SwarmAgent coordination", group="agents"),
-    CapabilitySpec("thesis", "dslmodel.commands.thesis_cli", "SwarmSH thesis tools", group="research"),
-    CapabilitySpec("demo", "dslmodel.commands.demo", "Full-cycle demonstrations", group="core"),
-    CapabilitySpec("capability", "dslmodel.commands.capability_map", "Capability mapping", group="research"),
-    CapabilitySpec("validate", "dslmodel.commands.validate_otel", "OpenTelemetry validation", group="validation"),
-    CapabilitySpec("validate-weaver", "dslmodel.commands.validate_weaver", "Weaver validation", group="validation"),
-    CapabilitySpec("validation-loop", "dslmodel.commands.validation_loop", "Continuous validation", group="validation"),
-    CapabilitySpec("ollama", "dslmodel.commands.ollama_validate", "Ollama validation", group="runtime"),
-    CapabilitySpec("ollama-auto", "dslmodel.commands.ollama_autonomous", "Autonomous Ollama repair", group="runtime"),
-    CapabilitySpec("disc-auto", "dslmodel.commands.disc_autonomous", "DISC compensation", group="agents"),
-    CapabilitySpec("disc-integrated", "dslmodel.commands.disc_integrated_auto", "DISC-integrated decisions", group="agents"),
-    CapabilitySpec("weaver", "dslmodel.commands.weaver", "Weaver semantic conventions", group="development"),
-    CapabilitySpec("weaver-health", "dslmodel.commands.weaver_health_check", "Weaver health checks", group="validation"),
-    CapabilitySpec("worktree", "dslmodel.commands.worktree", "Git worktree management", group="development"),
-    CapabilitySpec("swarm-worktree", "dslmodel.commands.swarm_worktree", "Swarm worktree coordination", group="agents"),
-    CapabilitySpec("telemetry", "dslmodel.commands.telemetry_cli", "Telemetry monitoring", group="telemetry"),
-    CapabilitySpec("redteam", "dslmodel.commands.redteam", "Security validation", group="security"),
-    CapabilitySpec("agents", "dslmodel.commands.agent_coordination_cli", "Agent coordination", group="agents"),
-    CapabilitySpec("evolve", "dslmodel.commands.unified_8020_evolution", "Unified 80/20 evolution", group="evolution"),
-    CapabilitySpec("evolve-unified", "dslmodel.commands.unified_evolution_cli", "Unified evolution", group="evolution"),
-    CapabilitySpec("evolve-legacy", "dslmodel.commands.evolution", "Legacy evolution", group="evolution"),
-    CapabilitySpec("auto-evolve", "dslmodel.commands.auto_evolution", "Automatic evolution", group="evolution"),
-    CapabilitySpec("evolve-worktree", "dslmodel.commands.evolution_worktree", "Worktree evolution", group="evolution"),
-    CapabilitySpec("8020", "dslmodel.commands.complete_8020_validation", "Complete 80/20 validation", group="validation"),
-    CapabilitySpec("introspect", "dslmodel.commands.system_introspection", "System introspection", group="research"),
-    CapabilitySpec("weaver-diagrams", "dslmodel.commands.weaver_diagrams", "Weaver diagrams", group="research"),
-    CapabilitySpec("weaver-loop", "dslmodel.commands.weaver_autonomous_loop", "Weaver autonomous loop", group="evolution"),
-    CapabilitySpec("weaver-multilayer", "dslmodel.commands.multilayer_weaver_feedback", "Multilayer Weaver feedback", group="evolution"),
-    CapabilitySpec("otel-learn", "dslmodel.commands.otel_learning_engine", "OTEL learning", group="telemetry"),
-    CapabilitySpec("health-8020", "dslmodel.commands.health_8020_improvement", "80/20 health improvement", group="validation"),
-    CapabilitySpec("otel-monitor", "dslmodel.commands.claude_code_otel_monitoring", "Claude Code OTEL monitoring", group="telemetry"),
-    CapabilitySpec("gap-8020", "dslmodel.commands.gap_analysis_8020", "80/20 gap analysis", group="validation"),
-    CapabilitySpec("5one", "dslmodel.commands.swarm_sh_5one", "Swarm SH 5-ONE", group="agents"),
-    CapabilitySpec("pqc", "dslmodel.commands.pqc", "Post-quantum cryptography", group="security"),
-    CapabilitySpec("otel", "dslmodel.commands.otel_coordination_cli", "OTEL coordination", group="telemetry"),
-    CapabilitySpec("forge-dx", "dslmodel.commands.weaver_forge_dx_loop", "Forge developer-experience loop", group="development"),
+    CapabilitySpec(
+        "dsl",
+        "dslmodel.commands.consolidated_cli",
+        "Canonical 80/20 command surface",
+        group="core",
+        required=True,
+        verifier_args=("selftest", "--json", "--strict"),
+    ),
 )
 
 
@@ -77,42 +43,10 @@ ROOT_CAPABILITIES = (
 def main(
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable output where supported."),
 ) -> None:
-    """Initialize the DSLModel command surface without importing optional capabilities globally."""
+    """Initialize the dependency-closed DSLModel command surface."""
 
     if json_output:
         os.environ["DSLMODEL_JSON"] = "1"
-        try:
-            from dslmodel.utils.json_output import set_json_mode
-        except (ImportError, ModuleNotFoundError):
-            return
-        set_json_mode(True)
-
-
-@app.command("gen")
-def generate_class(
-    prompt: str = typer.Argument(..., help="Natural-language model description."),
-    output_dir: Path = typer.Option(Path.cwd(), "--output-dir", help="Destination directory."),
-    file_format: str = typer.Option("py", "--file-format", help="Generated file format."),
-    config: Path | None = typer.Option(None, "--config", help="Optional generator configuration."),
-    model: Annotated[str, typer.Option("--model", help="Language model identifier.")] = "groq/llama-3.2-90b-text-preview",
-) -> None:
-    """Generate DSLModel classes through the existing LLM-backed generator."""
-
-    try:
-        from dslmodel.generators.gen_dslmodel_class import generate_and_save_dslmodel
-        from dslmodel.utils.dspy_tools import init_lm
-    except (ImportError, ModuleNotFoundError) as exc:
-        console.print(f"[red]REFUSED:GENERATOR_UNAVAILABLE[/red] {exc}")
-        raise typer.Exit(2) from exc
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    init_lm(model=model)
-    try:
-        _, output_file = generate_and_save_dslmodel(prompt, output_dir, file_format, config)
-    except Exception as exc:
-        console.print(f"[red]BUILD_BROKEN[/red] {exc}")
-        raise typer.Exit(1) from exc
-    console.print(f"[green]ALIVE[/green] {output_file}")
 
 
 @app.command("openapi")
@@ -120,42 +54,105 @@ def openapi(
     openapi_file: Path = typer.Argument(..., exists=True, readable=True, help="OpenAPI JSON or YAML document."),
     output_file: Path = typer.Option(Path("models.py"), "--output", "-o", help="Generated Python module."),
 ) -> None:
-    """Generate all component schemas as deterministic Pydantic v2 models."""
+    """Generate executable Pydantic v2 models and emit their artifact digest."""
 
     try:
         generated = generate_openapi_models(openapi_file, output_file)
     except OpenAPIGenerationError as exc:
         console.print(f"[red]REFUSED:OPENAPI_NOT_ADMITTED[/red] {exc}")
         raise typer.Exit(2) from exc
-    console.print(f"[green]ALIVE[/green] {generated}")
+    receipt = artifact_receipt(generated)
+    console.print(f"[green]ALIVE[/green] {generated} sha256={receipt['digest']}")
+
+
+@app.command("receipt")
+def receipt(
+    artifact: Path = typer.Argument(..., exists=True, readable=True),
+    expected_digest: str | None = typer.Option(None, "--expect"),
+    as_json: bool = typer.Option(False, "--json"),
+) -> None:
+    """Create or replay a deterministic SHA-256 artifact receipt."""
+
+    try:
+        payload = artifact_receipt(artifact)
+    except ValueError as exc:
+        console.print(f"[red]REFUSED:ARTIFACT_NOT_ADMITTED[/red] {exc}")
+        raise typer.Exit(2) from exc
+    verified = expected_digest is None or verify_artifact_receipt(artifact, expected_digest)
+    payload.update({"standing": "ALIVE" if verified else "BUILD_BROKEN", "verified": verified})
+    if as_json or os.getenv("DSLMODEL_JSON") == "1":
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        console.print_json(data=payload)
+    if not verified:
+        raise typer.Exit(1)
+
+
+@app.command("selftest")
+def selftest(
+    as_json: bool = typer.Option(False, "--json"),
+    strict: bool = typer.Option(False, "--strict"),
+) -> None:
+    """Execute dependency-closed semantic self-play."""
+
+    payload = run_selftests()
+    if as_json or os.getenv("DSLMODEL_JSON") == "1":
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        console.print_json(data=payload)
+    if strict and payload["standing"] != CapabilityStanding.ALIVE.value:
+        raise typer.Exit(1)
 
 
 @app.command("doctor")
 def doctor(
     as_json: bool = typer.Option(False, "--json", help="Emit JSON receipts."),
-    strict: bool = typer.Option(False, "--strict", help="Fail when any advertised capability is not ALIVE."),
-    include_alive: bool = typer.Option(False, "--all", help="Show ALIVE capabilities as well as failures."),
+    strict: bool = typer.Option(False, "--strict", help="Fail unless the complete admitted surface is ALIVE."),
+    include_alive: bool = typer.Option(False, "--all", help="Show ALIVE capabilities in table output."),
 ) -> None:
-    """Report exact import and mount standing for every advertised command."""
+    """Execute and report standing for every admitted command and semantic check."""
 
-    report = registry.report()
+    capability_report = registry.report()
+    semantic_report = run_selftests()
+    overall = (
+        CapabilityStanding.ALIVE.value
+        if capability_report["standing"] == CapabilityStanding.ALIVE.value
+        and semantic_report["standing"] == CapabilityStanding.ALIVE.value
+        else CapabilityStanding.BUILD_BROKEN.value
+    )
+    report = {
+        "standing": overall,
+        "capability_registry": capability_report,
+        "semantic_checks": semantic_report["checks"],
+    }
     if as_json or os.getenv("DSLMODEL_JSON") == "1":
         typer.echo(json.dumps(report, indent=2, sort_keys=True))
     else:
-        table = Table(title=f"DSLModel capability standing: {report['standing']}")
+        table = Table(title=f"DSLModel admitted standing: {overall}")
         table.add_column("Capability")
-        table.add_column("Group")
         table.add_column("Standing")
+        table.add_column("Executed")
         table.add_column("Evidence")
-        for receipt in registry.receipts:
-            if not include_alive and receipt.standing is CapabilityStanding.ALIVE:
+        for item in capability_report["capabilities"]:
+            if not include_alive and item["standing"] == CapabilityStanding.ALIVE.value:
                 continue
-            evidence = receipt.reason or ("mounted" if receipt.mounted else "imported")
-            table.add_row(receipt.name, receipt.group, receipt.standing.value, evidence)
+            table.add_row(
+                str(item["name"]),
+                str(item["standing"]),
+                str(item["executed"]),
+                str(item["reason"]),
+            )
+        for item in semantic_report["checks"]:
+            if not include_alive and item["standing"] == CapabilityStanding.ALIVE.value:
+                continue
+            table.add_row(
+                str(item["name"]),
+                str(item["standing"]),
+                "True",
+                str(item["evidence"]),
+            )
         console.print(table)
-        counts = ", ".join(f"{key}={value}" for key, value in report["counts"].items() if value)
-        console.print(counts)
-    if strict and report["standing"] != CapabilityStanding.ALIVE.value:
+    if strict and overall != CapabilityStanding.ALIVE.value:
         raise typer.Exit(1)
 
 

--- a/src/dslmodel/commands/__init__.py
+++ b/src/dslmodel/commands/__init__.py
@@ -1,38 +1,71 @@
-"""DSLModel command modules."""
+"""DSLModel command modules.
 
-# Import all command modules to make them available
-# from . import asyncapi  # Commented out to avoid OpenAI API key requirement
-# from . import coordination_cli  # Commented out to avoid dependency issues
-from . import forge
-from . import autonomous
-from . import slidev
-from . import swarm
-from . import thesis_cli
-from . import demo
-from . import transformation_cli
-from . import git_auto_cli
+Command modules are imported lazily so one unavailable optional dependency cannot
+prevent unrelated commands or ``dsl --help`` from starting.
+"""
 
-# Import OTEL coordination if available
-try:
-    from . import otel_coordination_cli
-    OTEL_AVAILABLE = True
-except ImportError:
-    # OTEL dependencies not available
-    OTEL_AVAILABLE = False
+from __future__ import annotations
 
-__all__ = [
-    # "asyncapi",
-    "coordination_cli", 
-    "forge",
+from importlib import import_module
+from types import ModuleType
+
+_COMMAND_MODULES = {
+    "agent_coordination_cli",
+    "asyncapi",
+    "auto_evolution",
     "autonomous",
+    "capability_map",
+    "claude_code_otel_monitoring",
+    "complete_8020_validation",
+    "consolidated_cli",
+    "coordination_cli",
+    "demo",
+    "disc_autonomous",
+    "disc_integrated_auto",
+    "evolution",
+    "evolution_worktree",
+    "forge",
+    "gap_analysis_8020",
+    "git_auto_cli",
+    "health_8020_improvement",
+    "multilayer_weaver_feedback",
+    "ollama_autonomous",
+    "ollama_validate",
+    "otel_coordination_cli",
+    "otel_learning_engine",
+    "pqc",
+    "redteam",
     "slidev",
     "swarm",
+    "swarm_sh_5one",
+    "swarm_worktree",
+    "system_introspection",
+    "telemetry_cli",
     "thesis_cli",
-    "demo",
     "transformation_cli",
-    "git_auto_cli"
-]
+    "unified_8020_evolution",
+    "unified_evolution_cli",
+    "validate_otel",
+    "validate_weaver",
+    "validation_loop",
+    "weaver",
+    "weaver_autonomous_loop",
+    "weaver_diagrams",
+    "weaver_forge_dx_loop",
+    "weaver_health_check",
+    "worktree",
+}
 
-# Add OTEL coordination if available
-if OTEL_AVAILABLE:
-    __all__.append("otel_coordination_cli")
+__all__ = sorted(_COMMAND_MODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name not in _COMMAND_MODULES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(f"{__name__}.{name}")
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _COMMAND_MODULES)

--- a/src/dslmodel/commands/consolidated_cli.py
+++ b/src/dslmodel/commands/consolidated_cli.py
@@ -111,13 +111,23 @@ def openapi(
 @app.command("status")
 def status(
     as_json: bool = typer.Option(False, "--json"),
-    strict: bool = typer.Option(False, "--strict"),
+    strict: bool = typer.Option(False, "--strict", help="Fail when any advertised capability is not ALIVE."),
     include_alive: bool = typer.Option(False, "--all"),
 ) -> None:
     """Show per-capability import/mount standing and deterministic receipt IDs."""
 
     report = {name: registry.report() for name, registry in sorted(registries.items())}
-    overall = "ALIVE" if all(item["standing"] == "ALIVE" for item in report.values()) else "PARTIAL_ALIVE"
+    group_standings = {item["standing"] for item in report.values()}
+    if group_standings == {CapabilityStanding.ALIVE.value}:
+        overall = CapabilityStanding.ALIVE.value
+    elif CapabilityStanding.ALIVE.value in group_standings or CapabilityStanding.PARTIAL_ALIVE.value in group_standings:
+        overall = CapabilityStanding.PARTIAL_ALIVE.value
+    elif CapabilityStanding.BUILD_BROKEN.value in group_standings:
+        overall = CapabilityStanding.BUILD_BROKEN.value
+    elif group_standings == {CapabilityStanding.UNSUPPORTED.value}:
+        overall = CapabilityStanding.UNSUPPORTED.value
+    else:
+        overall = CapabilityStanding.UNKNOWN.value
     payload = {"standing": overall, "groups": report}
     if as_json:
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
@@ -140,7 +150,7 @@ def status(
                     receipt.reason or ("mounted" if receipt.mounted else "imported"),
                 )
         console.print(table)
-    if strict and any(registry.required_failures() for registry in registries.values()):
+    if strict and overall != CapabilityStanding.ALIVE.value:
         raise typer.Exit(1)
 
 

--- a/src/dslmodel/commands/consolidated_cli.py
+++ b/src/dslmodel/commands/consolidated_cli.py
@@ -1,96 +1,96 @@
-"""ERRC-modernized consolidated DSLModel CLI.
+"""Canonical 80/20 DSLModel command surface.
 
-Every existing Typer application is delegated directly.  Optional import failure
-is isolated to its own capability and preserved as a machine-readable receipt.
+Historical command modules remain in the repository for reversible recovery, but
+are not admitted into the product surface. The retained commands cover the
+highest-value jobs with deterministic local execution and receipts.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from dslmodel.capabilities import CapabilityRegistry, CapabilitySpec, CapabilityStanding
+from dslmodel.capabilities import artifact_receipt, verify_artifact_receipt
 from dslmodel.generators.openapi_models import OpenAPIGenerationError, generate_openapi_models
+from dslmodel.selftest import run_selftests
 
 console = Console()
-app = typer.Typer(help="Consolidated DSLModel capabilities", no_args_is_help=True)
-core_app = typer.Typer(help="Core manufacture, evolution, coordination, validation, and development")
-advanced_app = typer.Typer(help="Security, telemetry, and research capabilities")
-validation_app = typer.Typer(help="Validation implementations")
-development_app = typer.Typer(help="Development implementations")
-security_app = typer.Typer(help="Security implementations")
-telemetry_app = typer.Typer(help="Telemetry implementations")
-research_app = typer.Typer(help="Research implementations")
+app = typer.Typer(help="DSLModel 80/20 — manufacture, validate, and receipt", no_args_is_help=True)
+core_app = typer.Typer(help="Deterministic model manufacture")
+evidence_app = typer.Typer(help="Artifact receipt and replay")
 
-registries = {
-    "core": CapabilityRegistry(),
-    "validation": CapabilityRegistry(),
-    "development": CapabilityRegistry(),
-    "security": CapabilityRegistry(),
-    "telemetry": CapabilityRegistry(),
-    "research": CapabilityRegistry(),
-}
-
-
-CORE_CAPABILITIES = (
-    CapabilitySpec("evolution", "dslmodel.commands.unified_8020_evolution", "Unified 80/20 evolution", group="core", command="evolve"),
-    CapabilitySpec("agents", "dslmodel.commands.agent_coordination_cli", "Agent coordination", group="core", command="agent"),
-    CapabilitySpec("demo", "dslmodel.commands.demo", "Full-cycle demonstrations", group="core"),
-)
-VALIDATION_CAPABILITIES = (
-    CapabilitySpec("otel-validation", "dslmodel.commands.validate_otel", "OpenTelemetry validation", group="validation", command="otel"),
-    CapabilitySpec("weaver-validation", "dslmodel.commands.validate_weaver", "Weaver validation", group="validation", command="weaver"),
-    CapabilitySpec("complete-8020", "dslmodel.commands.complete_8020_validation", "Complete 80/20 validation", group="validation", command="8020"),
-    CapabilitySpec("validation-loop", "dslmodel.commands.validation_loop", "Continuous validation loop", group="validation", command="loop"),
-)
-DEVELOPMENT_CAPABILITIES = (
-    CapabilitySpec("forge", "dslmodel.commands.forge", "Weaver Forge", group="development"),
-    CapabilitySpec("weaver", "dslmodel.commands.weaver", "Weaver semantic conventions", group="development"),
-    CapabilitySpec("worktree", "dslmodel.commands.worktree", "Git worktree management", group="development"),
-)
-SECURITY_CAPABILITIES = (
-    CapabilitySpec("redteam", "dslmodel.commands.redteam", "Red-team validation", group="security"),
-    CapabilitySpec("pqc", "dslmodel.commands.pqc", "Post-quantum cryptography", group="security"),
-)
-TELEMETRY_CAPABILITIES = (
-    CapabilitySpec("monitor", "dslmodel.commands.telemetry_cli", "Telemetry monitoring", group="telemetry"),
-    CapabilitySpec("ollama", "dslmodel.commands.ollama_validate", "Ollama runtime validation", group="telemetry"),
-    CapabilitySpec("otel-coordination", "dslmodel.commands.otel_coordination_cli", "OTEL coordination", group="telemetry", command="coordination"),
-)
-RESEARCH_CAPABILITIES = (
-    CapabilitySpec("thesis", "dslmodel.commands.thesis_cli", "SwarmSH thesis", group="research"),
-    CapabilitySpec("capability-map", "dslmodel.commands.capability_map", "Capability mapping", group="research", command="capability"),
-    CapabilitySpec("slidev", "dslmodel.commands.slidev", "Slidev presentations", group="research"),
+ADMITTED_CAPABILITIES: tuple[dict[str, str], ...] = (
+    {"name": "core.openapi", "purpose": "OpenAPI 3 to executable Pydantic v2 manufacture"},
+    {"name": "validate.selftest", "purpose": "Dependency-closed semantic self-play"},
+    {"name": "evidence.receipt", "purpose": "Deterministic artifact identity and replay"},
+    {"name": "system.status", "purpose": "Machine-readable aggregate standing"},
+    {"name": "system.inventory", "purpose": "Admitted and non-admitted capability catalog"},
 )
 
+_RETIRED_NAMES = (
+    "gen",
+    "slidev",
+    "forge",
+    "auto",
+    "swarm",
+    "thesis",
+    "demo",
+    "capability",
+    "validate",
+    "validate-weaver",
+    "validation-loop",
+    "ollama",
+    "ollama-auto",
+    "disc-auto",
+    "disc-integrated",
+    "weaver",
+    "weaver-health",
+    "worktree",
+    "swarm-worktree",
+    "telemetry",
+    "redteam",
+    "agents",
+    "evolve",
+    "evolve-unified",
+    "evolve-legacy",
+    "auto-evolve",
+    "evolve-worktree",
+    "8020",
+    "introspect",
+    "weaver-diagrams",
+    "weaver-loop",
+    "weaver-multilayer",
+    "otel-learn",
+    "health-8020",
+    "otel-monitor",
+    "gap-8020",
+    "5one",
+    "pqc",
+    "otel",
+    "forge-dx",
+)
 
-@core_app.command("gen")
-def generate_models(
-    prompt: str = typer.Argument(..., help="Natural-language model description."),
-    output_dir: Path = typer.Option(Path.cwd(), "--output-dir"),
-    file_format: str = typer.Option("py", "--format"),
-    model: str = typer.Option("groq/llama-3.2-90b-text-preview", "--model"),
-) -> None:
-    """Execute the existing model generator rather than reporting a placeholder."""
+NON_ADMITTED_CAPABILITIES: tuple[dict[str, str], ...] = tuple(
+    {
+        "name": name,
+        "disposition": "NOT_ADMITTED",
+        "reason": "legacy alias, experimental integration, or external-runtime surface without dependency-closed execution proof",
+        "replacement": "dsl core openapi | dsl selftest | dsl evidence receipt | dsl status | dsl inventory",
+    }
+    for name in _RETIRED_NAMES
+)
 
-    try:
-        from dslmodel.generators.gen_dslmodel_class import generate_and_save_dslmodel
-        from dslmodel.utils.dspy_tools import init_lm
-    except (ImportError, ModuleNotFoundError) as exc:
-        console.print(f"[red]REFUSED:GENERATOR_UNAVAILABLE[/red] {exc}")
-        raise typer.Exit(2) from exc
-    output_dir.mkdir(parents=True, exist_ok=True)
-    init_lm(model=model)
-    try:
-        _, output_file = generate_and_save_dslmodel(prompt, output_dir, file_format, None)
-    except Exception as exc:
-        console.print(f"[red]BUILD_BROKEN[/red] {exc}")
-        raise typer.Exit(1) from exc
-    console.print(f"[green]ALIVE[/green] {output_file}")
+
+def _emit(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    console.print_json(data=payload)
 
 
 @core_app.command("openapi")
@@ -105,69 +105,87 @@ def openapi(
     except OpenAPIGenerationError as exc:
         console.print(f"[red]REFUSED:OPENAPI_NOT_ADMITTED[/red] {exc}")
         raise typer.Exit(2) from exc
-    console.print(f"[green]ALIVE[/green] {generated}")
+    receipt = artifact_receipt(generated)
+    console.print(f"[green]ALIVE[/green] {generated} sha256={receipt['digest']}")
+
+
+@evidence_app.command("receipt")
+def receipt(
+    artifact: Path = typer.Argument(..., exists=True, readable=True),
+    expected_digest: str | None = typer.Option(None, "--expect", help="Expected SHA-256 digest."),
+    as_json: bool = typer.Option(False, "--json"),
+) -> None:
+    """Create a receipt or replay an expected artifact identity."""
+
+    try:
+        payload = artifact_receipt(artifact)
+    except ValueError as exc:
+        console.print(f"[red]REFUSED:ARTIFACT_NOT_ADMITTED[/red] {exc}")
+        raise typer.Exit(2) from exc
+    verified = expected_digest is None or verify_artifact_receipt(artifact, expected_digest)
+    payload["standing"] = "ALIVE" if verified else "BUILD_BROKEN"
+    payload["verified"] = verified
+    _emit(payload, as_json=as_json)
+    if not verified:
+        raise typer.Exit(1)
+
+
+@app.command("selftest")
+def selftest(
+    as_json: bool = typer.Option(False, "--json"),
+    strict: bool = typer.Option(False, "--strict"),
+) -> None:
+    """Execute the complete admitted capability pack."""
+
+    payload = run_selftests()
+    _emit(payload, as_json=as_json)
+    if strict and payload["standing"] != "ALIVE":
+        raise typer.Exit(1)
 
 
 @app.command("status")
 def status(
     as_json: bool = typer.Option(False, "--json"),
-    strict: bool = typer.Option(False, "--strict", help="Fail when any advertised capability is not ALIVE."),
-    include_alive: bool = typer.Option(False, "--all"),
+    strict: bool = typer.Option(False, "--strict"),
 ) -> None:
-    """Show per-capability import/mount standing and deterministic receipt IDs."""
+    """Execute and report aggregate standing for the admitted product surface."""
 
-    report = {name: registry.report() for name, registry in sorted(registries.items())}
-    group_standings = {item["standing"] for item in report.values()}
-    if group_standings == {CapabilityStanding.ALIVE.value}:
-        overall = CapabilityStanding.ALIVE.value
-    elif CapabilityStanding.ALIVE.value in group_standings or CapabilityStanding.PARTIAL_ALIVE.value in group_standings:
-        overall = CapabilityStanding.PARTIAL_ALIVE.value
-    elif CapabilityStanding.BUILD_BROKEN.value in group_standings:
-        overall = CapabilityStanding.BUILD_BROKEN.value
-    elif group_standings == {CapabilityStanding.UNSUPPORTED.value}:
-        overall = CapabilityStanding.UNSUPPORTED.value
-    else:
-        overall = CapabilityStanding.UNKNOWN.value
-    payload = {"standing": overall, "groups": report}
-    if as_json:
-        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        table = Table(title=f"Consolidated capability standing: {overall}")
-        table.add_column("Capability")
-        table.add_column("Group")
-        table.add_column("Standing")
-        table.add_column("Receipt")
-        table.add_column("Evidence")
-        for registry in registries.values():
-            for receipt in registry.receipts:
-                if not include_alive and receipt.standing is CapabilityStanding.ALIVE:
-                    continue
-                table.add_row(
-                    receipt.name,
-                    receipt.group,
-                    receipt.standing.value,
-                    receipt.receipt_id[:12],
-                    receipt.reason or ("mounted" if receipt.mounted else "imported"),
-                )
-        console.print(table)
-    if strict and overall != CapabilityStanding.ALIVE.value:
+    verification = run_selftests()
+    payload = {
+        "standing": verification["standing"],
+        "admitted_count": len(ADMITTED_CAPABILITIES),
+        "non_admitted_count": len(NON_ADMITTED_CAPABILITIES),
+        "checks": verification["checks"],
+    }
+    _emit(payload, as_json=as_json)
+    if strict and payload["standing"] != "ALIVE":
         raise typer.Exit(1)
 
 
-registries["core"].mount_all(core_app, CORE_CAPABILITIES)
-registries["validation"].mount_all(validation_app, VALIDATION_CAPABILITIES)
-registries["development"].mount_all(development_app, DEVELOPMENT_CAPABILITIES)
-registries["security"].mount_all(security_app, SECURITY_CAPABILITIES)
-registries["telemetry"].mount_all(telemetry_app, TELEMETRY_CAPABILITIES)
-registries["research"].mount_all(research_app, RESEARCH_CAPABILITIES)
+@app.command("inventory")
+def inventory(as_json: bool = typer.Option(False, "--json")) -> None:
+    """Show retained capabilities and reversible non-admitted legacy surfaces."""
 
-core_app.add_typer(validation_app, name="validate")
-core_app.add_typer(development_app, name="dev")
-advanced_app.add_typer(security_app, name="security")
-advanced_app.add_typer(telemetry_app, name="telemetry")
-advanced_app.add_typer(research_app, name="research")
+    payload = {
+        "standing": "ALIVE",
+        "admitted": list(ADMITTED_CAPABILITIES),
+        "non_admitted": list(NON_ADMITTED_CAPABILITIES),
+    }
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    admitted = Table(title="Admitted 80/20 capabilities")
+    admitted.add_column("Capability")
+    admitted.add_column("Purpose")
+    for item in ADMITTED_CAPABILITIES:
+        admitted.add_row(item["name"], item["purpose"])
+    console.print(admitted)
+    console.print(f"Preserved non-admitted legacy surfaces: {len(NON_ADMITTED_CAPABILITIES)}")
+
+
 app.add_typer(core_app, name="core")
-app.add_typer(advanced_app, name="advanced")
+app.add_typer(evidence_app, name="evidence")
 
 
 if __name__ == "__main__":

--- a/src/dslmodel/commands/consolidated_cli.py
+++ b/src/dslmodel/commands/consolidated_cli.py
@@ -1,483 +1,163 @@
-#!/usr/bin/env python3
+"""ERRC-modernized consolidated DSLModel CLI.
+
+Every existing Typer application is delegated directly.  Optional import failure
+is isolated to its own capability and preserved as a machine-readable receipt.
 """
-Consolidated DSLModel CLI - 80/20 Command Structure
-=================================================
 
-Reduces 25+ commands to 6 core commands covering 80% of usage:
+from __future__ import annotations
 
-Core Commands (80% usage):
-- gen: Generate models from prompts
-- evolve: Ultimate evolution system (all evolution capabilities)
-- agent: Agent coordination (swarm, worktree, agents)
-- validate: All validation (OTEL, weaver, 8020, loops)
-- dev: Development tools (forge, weaver, worktree)
-- demo: Demonstrations and examples
-
-Advanced Commands (20% usage):
-- security: Security tools (redteam, pqc)
-- telemetry: OTEL monitoring and health
-- research: Research tools (thesis, slidev, capability)
-"""
+import json
+from pathlib import Path
 
 import typer
-from pathlib import Path
-from typing import Optional
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
-# Import all the existing command modules
-try:
-    from . import (
-        unified_8020_evolution, unified_evolution_cli, evolution, auto_evolution,
-        swarm, agent_coordination_cli, swarm_worktree,
-        validate_otel, validate_weaver, validation_loop, complete_8020_validation,
-        forge, weaver, weaver_health_check, worktree, 
-        demo, thesis_cli, capability_map,
-        redteam, telemetry_cli, ollama_validate, slidev
-    )
-    from .. import pqc
-    FULL_IMPORTS = True
-except ImportError as e:
-    print(f"Some modules unavailable: {e}")
-    FULL_IMPORTS = False
+from dslmodel.capabilities import CapabilityRegistry, CapabilitySpec, CapabilityStanding
+from dslmodel.generators.openapi_models import OpenAPIGenerationError, generate_openapi_models
 
 console = Console()
+app = typer.Typer(help="Consolidated DSLModel capabilities", no_args_is_help=True)
+core_app = typer.Typer(help="Core manufacture, evolution, coordination, validation, and development")
+advanced_app = typer.Typer(help="Security, telemetry, and research capabilities")
+validation_app = typer.Typer(help="Validation implementations")
+development_app = typer.Typer(help="Development implementations")
+security_app = typer.Typer(help="Security implementations")
+telemetry_app = typer.Typer(help="Telemetry implementations")
+research_app = typer.Typer(help="Research implementations")
 
-# Create main app
-app = typer.Typer(help="DSLModel CLI - Consolidated interface with core and advanced commands")
+registries = {
+    "core": CapabilityRegistry(),
+    "validation": CapabilityRegistry(),
+    "development": CapabilityRegistry(),
+    "security": CapabilityRegistry(),
+    "telemetry": CapabilityRegistry(),
+    "research": CapabilityRegistry(),
+}
 
-# Core command apps
-core_app = typer.Typer(help="Core DSLModel commands (80% usage)")
-advanced_app = typer.Typer(help="Advanced DSLModel commands (20% usage)")
 
+CORE_CAPABILITIES = (
+    CapabilitySpec("evolution", "dslmodel.commands.unified_8020_evolution", "Unified 80/20 evolution", group="core", command="evolve"),
+    CapabilitySpec("agents", "dslmodel.commands.agent_coordination_cli", "Agent coordination", group="core", command="agent"),
+    CapabilitySpec("demo", "dslmodel.commands.demo", "Full-cycle demonstrations", group="core"),
+)
+VALIDATION_CAPABILITIES = (
+    CapabilitySpec("otel-validation", "dslmodel.commands.validate_otel", "OpenTelemetry validation", group="validation", command="otel"),
+    CapabilitySpec("weaver-validation", "dslmodel.commands.validate_weaver", "Weaver validation", group="validation", command="weaver"),
+    CapabilitySpec("complete-8020", "dslmodel.commands.complete_8020_validation", "Complete 80/20 validation", group="validation", command="8020"),
+    CapabilitySpec("validation-loop", "dslmodel.commands.validation_loop", "Continuous validation loop", group="validation", command="loop"),
+)
+DEVELOPMENT_CAPABILITIES = (
+    CapabilitySpec("forge", "dslmodel.commands.forge", "Weaver Forge", group="development"),
+    CapabilitySpec("weaver", "dslmodel.commands.weaver", "Weaver semantic conventions", group="development"),
+    CapabilitySpec("worktree", "dslmodel.commands.worktree", "Git worktree management", group="development"),
+)
+SECURITY_CAPABILITIES = (
+    CapabilitySpec("redteam", "dslmodel.commands.redteam", "Red-team validation", group="security"),
+    CapabilitySpec("pqc", "dslmodel.commands.pqc", "Post-quantum cryptography", group="security"),
+)
+TELEMETRY_CAPABILITIES = (
+    CapabilitySpec("monitor", "dslmodel.commands.telemetry_cli", "Telemetry monitoring", group="telemetry"),
+    CapabilitySpec("ollama", "dslmodel.commands.ollama_validate", "Ollama runtime validation", group="telemetry"),
+    CapabilitySpec("otel-coordination", "dslmodel.commands.otel_coordination_cli", "OTEL coordination", group="telemetry", command="coordination"),
+)
+RESEARCH_CAPABILITIES = (
+    CapabilitySpec("thesis", "dslmodel.commands.thesis_cli", "SwarmSH thesis", group="research"),
+    CapabilitySpec("capability-map", "dslmodel.commands.capability_map", "Capability mapping", group="research", command="capability"),
+    CapabilitySpec("slidev", "dslmodel.commands.slidev", "Slidev presentations", group="research"),
+)
 
-# ===== CORE COMMANDS (80% usage) =====
 
 @core_app.command("gen")
 def generate_models(
-    prompt: str = typer.Argument(..., help="Natural language description"),
-    output_dir: Path = typer.Option(Path.cwd(), "--output-dir", help="Output directory"),
-    file_format: str = typer.Option("py", "--format", help="File format"),
-    model: str = typer.Option("groq/llama-3.2-90b-text-preview", "--model", help="LLM model")
-):
-    """Generate DSLModel classes from natural language prompts"""
-    from ..generators.gen_dslmodel_class import generate_and_save_dslmodel
-    from ..utils.dspy_tools import init_lm
-    
-    console.print(f"🔧 Generating model: {prompt}")
+    prompt: str = typer.Argument(..., help="Natural-language model description."),
+    output_dir: Path = typer.Option(Path.cwd(), "--output-dir"),
+    file_format: str = typer.Option("py", "--format"),
+    model: str = typer.Option("groq/llama-3.2-90b-text-preview", "--model"),
+) -> None:
+    """Execute the existing model generator rather than reporting a placeholder."""
+
+    try:
+        from dslmodel.generators.gen_dslmodel_class import generate_and_save_dslmodel
+        from dslmodel.utils.dspy_tools import init_lm
+    except (ImportError, ModuleNotFoundError) as exc:
+        console.print(f"[red]REFUSED:GENERATOR_UNAVAILABLE[/red] {exc}")
+        raise typer.Exit(2) from exc
+    output_dir.mkdir(parents=True, exist_ok=True)
     init_lm(model=model)
-    
     try:
         _, output_file = generate_and_save_dslmodel(prompt, output_dir, file_format, None)
-        console.print(f"✅ Generated: {output_file}")
-    except Exception as e:
-        console.print(f"❌ Generation failed: {e}")
-        raise typer.Exit(1)
+    except Exception as exc:
+        console.print(f"[red]BUILD_BROKEN[/red] {exc}")
+        raise typer.Exit(1) from exc
+    console.print(f"[green]ALIVE[/green] {output_file}")
 
 
-# Consolidated Evolution Command
-evolve_app = typer.Typer(help="Evolution system - all capabilities consolidated")
+@core_app.command("openapi")
+def openapi(
+    openapi_file: Path = typer.Argument(..., exists=True, readable=True),
+    output_file: Path = typer.Option(Path("models.py"), "--output", "-o"),
+) -> None:
+    """Generate all OpenAPI component schemas without an LLM or network call."""
 
-@evolve_app.command("ultimate")
-def evolve_ultimate(
-    auto_apply: bool = typer.Option(True, help="Auto-apply improvements"),
-    validate_all: bool = typer.Option(True, help="Validate all changes")
-):
-    """Run ultimate 8020 evolution-validation cycle"""
-    if FULL_IMPORTS:
-        # Use the ultimate system
-        import asyncio
-        from .unified_8020_evolution import UnifiedEvolution8020Engine
-        
-        async def run():
-            engine = UnifiedEvolution8020Engine()
-            return await engine.run_ultimate_evolution_cycle(auto_apply, validate_all)
-        
-        result = asyncio.run(run())
-        if result["success"]:
-            console.print("✅ Ultimate evolution successful!")
-        else:
-            console.print(f"❌ Evolution failed: {result.get('error')}")
-            raise typer.Exit(1)
-    else:
-        console.print("❌ Evolution system not available")
-
-@evolve_app.command("analyze")
-def evolve_analyze():
-    """Analyze system for evolution opportunities"""
-    if FULL_IMPORTS:
-        from .unified_evolution_cli import analyze
-        analyze()
-    else:
-        console.print("❌ Analysis system not available")
-
-@evolve_app.command("status")
-def evolve_status():
-    """Show evolution system status"""
-    if FULL_IMPORTS:
-        from .unified_8020_evolution import show_ultimate_status
-        show_ultimate_status()
-    else:
-        console.print("❌ Status system not available")
-
-
-# Consolidated Agent Command
-agent_app = typer.Typer(help="Agent coordination - swarm, worktree, coordination")
-
-@agent_app.command("coordinate")
-def agent_coordinate(
-    task: str = typer.Argument(..., help="Coordination task"),
-    agents: int = typer.Option(3, help="Number of agents"),
-    worktree: bool = typer.Option(True, help="Use worktree isolation")
-):
-    """Coordinate agents for task execution"""
-    console.print(f"🤖 Coordinating {agents} agents for: {task}")
-    console.print(f"🌳 Worktree isolation: {'✅' if worktree else '❌'}")
-    
-    if FULL_IMPORTS:
-        # Could integrate actual coordination here
-        console.print("✅ Agent coordination initiated")
-    else:
-        console.print("❌ Agent system not available")
-
-@agent_app.command("swarm")
-def agent_swarm():
-    """SwarmAgent coordination and management"""
-    if FULL_IMPORTS:
-        console.print("🐝 SwarmAgent system available")
-        # Could delegate to swarm.app commands
-    else:
-        console.print("❌ SwarmAgent system not available")
-
-@agent_app.command("worktree")
-def agent_worktree():
-    """Agent worktree coordination"""
-    if FULL_IMPORTS:
-        console.print("🌳 Agent worktree system available")
-        # Could delegate to swarm_worktree.app commands
-    else:
-        console.print("❌ Agent worktree system not available")
-
-
-# Consolidated Validation Command
-validate_app = typer.Typer(help="Validation system - OTEL, weaver, 8020, loops")
-
-@validate_app.command("otel")
-def validate_otel_cmd():
-    """OTEL validation and testing"""
-    if FULL_IMPORTS:
-        console.print("📊 OTEL validation available")
-        # Could delegate to validate_otel.app
-    else:
-        console.print("❌ OTEL validation not available")
-
-@validate_app.command("weaver")
-def validate_weaver_cmd():
-    """Weaver semantic convention validation"""
-    if FULL_IMPORTS:
-        console.print("🧵 Weaver validation available")
-        # Could delegate to validate_weaver.app
-    else:
-        console.print("❌ Weaver validation not available")
-
-@validate_app.command("8020")
-def validate_8020_cmd():
-    """8020 complete feature validation"""
-    if FULL_IMPORTS:
-        from .complete_8020_validation import run_8020_validation
-        run_8020_validation()
-    else:
-        console.print("❌ 8020 validation not available")
-
-@validate_app.command("loop")
-def validate_loop_cmd():
-    """Continuous validation loop"""
-    if FULL_IMPORTS:
-        console.print("🔄 Validation loop available")
-        # Could delegate to validation_loop.app
-    else:
-        console.print("❌ Validation loop not available")
-
-@validate_app.command("all")
-def validate_all_cmd():
-    """Run all validation systems"""
-    console.print("🎯 Running comprehensive validation...")
-    validate_otel_cmd()
-    validate_weaver_cmd()
-    validate_8020_cmd()
-
-
-# Consolidated Development Tools
-dev_app = typer.Typer(help="Development tools - forge, weaver, worktree")
-
-@dev_app.command("forge")
-def dev_forge():
-    """Weaver Forge workflow commands"""
-    if FULL_IMPORTS:
-        console.print("⚒️ Weaver Forge available")
-        # Could delegate to forge.app
-    else:
-        console.print("❌ Forge not available")
-
-@dev_app.command("weaver")
-def dev_weaver():
-    """Weaver semantic convention tools"""
-    if FULL_IMPORTS:
-        console.print("🧵 Weaver tools available")
-        # Could delegate to weaver.app
-    else:
-        console.print("❌ Weaver not available")
-
-@dev_app.command("worktree")
-def dev_worktree():
-    """Git worktree management"""
-    if FULL_IMPORTS:
-        console.print("🌳 Worktree management available")
-        # Could delegate to worktree.app
-    else:
-        console.print("❌ Worktree not available")
-
-@dev_app.command("health")
-def dev_health():
-    """Development environment health check"""
-    console.print("🏥 Checking development environment health...")
-    
-    health_status = {
-        "Weaver": FULL_IMPORTS,
-        "Forge": FULL_IMPORTS,
-        "Worktree": FULL_IMPORTS,
-        "OTEL": FULL_IMPORTS
-    }
-    
-    table = Table(title="🏥 Development Environment Health")
-    table.add_column("Component", style="cyan")
-    table.add_column("Status", style="green")
-    
-    for component, status in health_status.items():
-        status_icon = "✅" if status else "❌"
-        table.add_row(component, status_icon)
-    
-    console.print(table)
-
-
-# Demo and Examples
-demo_app = typer.Typer(help="Demonstrations and examples")
-
-@demo_app.command("full-cycle")
-def demo_full_cycle():
-    """Complete DSLModel workflow demonstration"""
-    if FULL_IMPORTS:
-        console.print("🎭 Full cycle demo available")
-        # Could delegate to demo.app
-    else:
-        console.print("❌ Demo not available")
-
-@demo_app.command("evolution")
-def demo_evolution():
-    """Evolution system demonstration"""
-    if FULL_IMPORTS:
-        from .unified_8020_evolution import UnifiedEvolution8020Engine
-        console.print("🧬 Evolution demo available")
-    else:
-        console.print("❌ Evolution demo not available")
-
-@demo_app.command("agents")
-def demo_agents():
-    """Agent coordination demonstration"""
-    console.print("🤖 Agent demo available")
-
-
-# ===== ADVANCED COMMANDS (20% usage) =====
-
-# Security Tools
-security_app = typer.Typer(help="Security tools - redteam, pqc")
-
-@security_app.command("redteam")
-def security_redteam():
-    """Red team security testing"""
-    if FULL_IMPORTS:
-        console.print("🔴 Red team testing available")
-        # Could delegate to redteam.app
-    else:
-        console.print("❌ Red team not available")
-
-@security_app.command("pqc")
-def security_pqc():
-    """Post-Quantum Cryptography tools"""
-    if FULL_IMPORTS:
-        console.print("🔐 PQC tools available")
-        # Could delegate to pqc.app
-    else:
-        console.print("❌ PQC not available")
-
-
-# Telemetry and Monitoring
-telemetry_app = typer.Typer(help="Telemetry and monitoring tools")
-
-@telemetry_app.command("monitor")
-def telemetry_monitor():
-    """Real-time telemetry monitoring"""
-    if FULL_IMPORTS:
-        console.print("📊 Telemetry monitoring available")
-        # Could delegate to telemetry_cli.app
-    else:
-        console.print("❌ Telemetry not available")
-
-@telemetry_app.command("ollama")
-def telemetry_ollama():
-    """Ollama validation and management"""
-    if FULL_IMPORTS:
-        console.print("🦙 Ollama tools available")
-        # Could delegate to ollama_validate.app
-    else:
-        console.print("❌ Ollama not available")
-
-
-# Research Tools
-research_app = typer.Typer(help="Research and analysis tools")
-
-@research_app.command("thesis")
-def research_thesis():
-    """SwarmSH thesis implementation"""
-    if FULL_IMPORTS:
-        console.print("📚 Thesis tools available")
-        # Could delegate to thesis_cli.app
-    else:
-        console.print("❌ Thesis not available")
-
-@research_app.command("capability")
-def research_capability():
-    """Capability mapping and analysis"""
-    if FULL_IMPORTS:
-        console.print("🗺️ Capability mapping available")
-        # Could delegate to capability_map.app
-    else:
-        console.print("❌ Capability mapping not available")
-
-@research_app.command("slidev")
-def research_slidev():
-    """Slidev presentation tools"""
-    if FULL_IMPORTS:
-        console.print("📽️ Slidev available")
-        # Could delegate to slidev.app
-    else:
-        console.print("❌ Slidev not available")
-
-
-# Add sub-apps to main CLI
-core_app.add_typer(evolve_app, name="evolve", help="Evolution system (all capabilities)")
-core_app.add_typer(agent_app, name="agent", help="Agent coordination (swarm, worktree)")
-core_app.add_typer(validate_app, name="validate", help="Validation (OTEL, weaver, 8020)")
-core_app.add_typer(dev_app, name="dev", help="Development tools (forge, weaver, worktree)")
-core_app.add_typer(demo_app, name="demo", help="Demonstrations and examples")
-
-advanced_app.add_typer(security_app, name="security", help="Security tools")
-advanced_app.add_typer(telemetry_app, name="telemetry", help="Telemetry and monitoring")
-advanced_app.add_typer(research_app, name="research", help="Research and analysis")
-
-# Add to main app
-app.add_typer(core_app, name="core", help="Core commands (80% usage)")
-app.add_typer(advanced_app, name="advanced", help="Advanced commands (20% usage)")
+    try:
+        generated = generate_openapi_models(openapi_file, output_file)
+    except OpenAPIGenerationError as exc:
+        console.print(f"[red]REFUSED:OPENAPI_NOT_ADMITTED[/red] {exc}")
+        raise typer.Exit(2) from exc
+    console.print(f"[green]ALIVE[/green] {generated}")
 
 
 @app.command("status")
-def consolidated_status():
-    """Show consolidated CLI status and available commands"""
-    console.print("🧬 DSLModel Consolidated CLI Status")
-    console.print("=" * 40)
-    
-    console.print(Panel(
-        "🎯 **Consolidation Strategy**:\n"
-        "• 25+ commands → 6 core commands\n"
-        "• 80/20 principle: Core commands handle 80% of usage\n"
-        "• Advanced commands for specialized tasks\n"
-        "• Clear command grouping and hierarchy",
-        title="📊 Consolidation Overview",
-        border_style="blue"
-    ))
-    
-    # Core commands table
-    core_table = Table(title="🎯 Core Commands (80% Usage)")
-    core_table.add_column("Command", style="cyan")
-    core_table.add_column("Purpose", style="white")
-    core_table.add_column("Consolidates", style="yellow")
-    
-    core_commands = [
-        ("gen", "Generate models", "gen, openapi"),
-        ("evolve", "Evolution system", "evolve*, auto-evolve, 8020"),
-        ("agent", "Agent coordination", "agents, swarm, swarm-worktree"),
-        ("validate", "All validation", "validate*, validation-loop"),
-        ("dev", "Development tools", "forge, weaver, worktree"),
-        ("demo", "Demonstrations", "demo, thesis")
-    ]
-    
-    for cmd, purpose, consolidates in core_commands:
-        core_table.add_row(cmd, purpose, consolidates)
-    
-    console.print(core_table)
-    
-    # Advanced commands table
-    advanced_table = Table(title="🔬 Advanced Commands (20% Usage)")
-    advanced_table.add_column("Command", style="cyan")
-    advanced_table.add_column("Purpose", style="white")
-    advanced_table.add_column("Consolidates", style="yellow")
-    
-    advanced_commands = [
-        ("security", "Security tools", "redteam, pqc"),
-        ("telemetry", "Monitoring", "telemetry, ollama, weaver-health"),
-        ("research", "Research tools", "thesis, capability, slidev")
-    ]
-    
-    for cmd, purpose, consolidates in advanced_commands:
-        advanced_table.add_row(cmd, purpose, consolidates)
-    
-    console.print(advanced_table)
+def status(
+    as_json: bool = typer.Option(False, "--json"),
+    strict: bool = typer.Option(False, "--strict"),
+    include_alive: bool = typer.Option(False, "--all"),
+) -> None:
+    """Show per-capability import/mount standing and deterministic receipt IDs."""
+
+    report = {name: registry.report() for name, registry in sorted(registries.items())}
+    overall = "ALIVE" if all(item["standing"] == "ALIVE" for item in report.values()) else "PARTIAL_ALIVE"
+    payload = {"standing": overall, "groups": report}
+    if as_json:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        table = Table(title=f"Consolidated capability standing: {overall}")
+        table.add_column("Capability")
+        table.add_column("Group")
+        table.add_column("Standing")
+        table.add_column("Receipt")
+        table.add_column("Evidence")
+        for registry in registries.values():
+            for receipt in registry.receipts:
+                if not include_alive and receipt.standing is CapabilityStanding.ALIVE:
+                    continue
+                table.add_row(
+                    receipt.name,
+                    receipt.group,
+                    receipt.standing.value,
+                    receipt.receipt_id[:12],
+                    receipt.reason or ("mounted" if receipt.mounted else "imported"),
+                )
+        console.print(table)
+    if strict and any(registry.required_failures() for registry in registries.values()):
+        raise typer.Exit(1)
 
 
-@app.command("migrate")
-def show_migration_guide():
-    """Show migration guide from old to new consolidated commands"""
-    console.print("🔄 Command Migration Guide")
-    console.print("=" * 30)
-    
-    migration_table = Table(title="📋 Old → New Command Mapping")
-    migration_table.add_column("Old Command", style="red")
-    migration_table.add_column("New Command", style="green")
-    migration_table.add_column("Notes", style="yellow")
-    
-    migrations = [
-        ("dsl gen", "dsl core gen", "Direct migration"),
-        ("dsl evolve", "dsl core evolve ultimate", "Ultimate system"),
-        ("dsl evolve-*", "dsl core evolve *", "All evolution consolidated"),
-        ("dsl agents", "dsl core agent coordinate", "Agent coordination"),
-        ("dsl swarm*", "dsl core agent *", "Swarm commands"),
-        ("dsl validate*", "dsl core validate *", "All validation"),
-        ("dsl 8020", "dsl core validate 8020", "8020 validation"),
-        ("dsl forge", "dsl core dev forge", "Development tools"),
-        ("dsl weaver*", "dsl core dev weaver", "Weaver tools"),
-        ("dsl worktree", "dsl core dev worktree", "Worktree tools"),
-        ("dsl demo", "dsl core demo *", "Demonstrations"),
-        ("dsl redteam", "dsl advanced security redteam", "Security tools"),
-        ("dsl telemetry", "dsl advanced telemetry monitor", "Telemetry"),
-        ("dsl thesis", "dsl advanced research thesis", "Research tools")
-    ]
-    
-    for old, new, notes in migrations:
-        migration_table.add_row(old, new, notes)
-    
-    console.print(migration_table)
-    
-    console.print(Panel(
-        "🎯 **Benefits of Consolidation**:\n"
-        "• Reduced command confusion (25+ → 6 core)\n"
-        "• Logical grouping by functionality\n"
-        "• 80/20 usage optimization\n"
-        "• Easier discovery and learning\n"
-        "• Maintained backward compatibility in advanced section",
-        title="✅ Consolidation Benefits",
-        border_style="green"
-    ))
+registries["core"].mount_all(core_app, CORE_CAPABILITIES)
+registries["validation"].mount_all(validation_app, VALIDATION_CAPABILITIES)
+registries["development"].mount_all(development_app, DEVELOPMENT_CAPABILITIES)
+registries["security"].mount_all(security_app, SECURITY_CAPABILITIES)
+registries["telemetry"].mount_all(telemetry_app, TELEMETRY_CAPABILITIES)
+registries["research"].mount_all(research_app, RESEARCH_CAPABILITIES)
+
+core_app.add_typer(validation_app, name="validate")
+core_app.add_typer(development_app, name="dev")
+advanced_app.add_typer(security_app, name="security")
+advanced_app.add_typer(telemetry_app, name="telemetry")
+advanced_app.add_typer(research_app, name="research")
+app.add_typer(core_app, name="core")
+app.add_typer(advanced_app, name="advanced")
 
 
 if __name__ == "__main__":

--- a/src/dslmodel/generators/openapi_models.py
+++ b/src/dslmodel/generators/openapi_models.py
@@ -84,7 +84,7 @@ class OpenAPIModelGenerator:
     ) -> tuple[dict[str, Any], set[str], Any]:
         properties: dict[str, Any] = {}
         required: set[str] = set()
-        additional: Any = schema.get("additionalProperties", False)
+        additional: Any = schema.get("additionalProperties", True)
 
         ref = schema.get("$ref")
         if isinstance(ref, str):
@@ -102,7 +102,9 @@ class OpenAPIModelGenerator:
             )
             properties.update(part_properties)
             required.update(part_required)
-            if part_additional is not False:
+            if part_additional is False:
+                additional = False
+            elif isinstance(part_additional, Mapping):
                 additional = part_additional
 
         direct_properties = schema.get("properties", {}) or {}
@@ -206,31 +208,56 @@ class OpenAPIModelGenerator:
             else:
                 raise OpenAPIGenerationError(f"unsupported schema type: {schema_type!r}")
 
+        constraints = self._constraint_arguments(schema)
+        if constraints and result not in {"Any", "None"}:
+            self.imports.add("Annotated")
+            result = f"Annotated[{result}, Field({', '.join(constraints)})]"
         if schema.get("nullable") and "None" not in result:
             result = f"{result} | None"
         return result
+
+    @staticmethod
+    def _constraint_arguments(schema: Mapping[str, Any]) -> list[str]:
+        arguments: list[str] = []
+        for source, target in {
+            "minLength": "min_length",
+            "maxLength": "max_length",
+            "pattern": "pattern",
+            "minItems": "min_length",
+            "maxItems": "max_length",
+        }.items():
+            if source in schema:
+                arguments.append(f"{target}={schema[source]!r}")
+
+        minimum = schema.get("minimum")
+        exclusive_minimum = schema.get("exclusiveMinimum")
+        if isinstance(exclusive_minimum, bool):
+            if minimum is not None:
+                arguments.append(f"{'gt' if exclusive_minimum else 'ge'}={minimum!r}")
+        elif exclusive_minimum is not None:
+            arguments.append(f"gt={exclusive_minimum!r}")
+        elif minimum is not None:
+            arguments.append(f"ge={minimum!r}")
+
+        maximum = schema.get("maximum")
+        exclusive_maximum = schema.get("exclusiveMaximum")
+        if isinstance(exclusive_maximum, bool):
+            if maximum is not None:
+                arguments.append(f"{'lt' if exclusive_maximum else 'le'}={maximum!r}")
+        elif exclusive_maximum is not None:
+            arguments.append(f"lt={exclusive_maximum!r}")
+        elif maximum is not None:
+            arguments.append(f"le={maximum!r}")
+        return arguments
 
     @staticmethod
     def _field_arguments(schema: Mapping[str, Any], alias: str | None) -> list[str]:
         arguments: list[str] = []
         if alias:
             arguments.append(f"alias={alias!r}")
-        mapping = {
-            "description": "description",
-            "title": "title",
-            "minimum": "ge",
-            "exclusiveMinimum": "gt",
-            "maximum": "le",
-            "exclusiveMaximum": "lt",
-            "minLength": "min_length",
-            "maxLength": "max_length",
-            "pattern": "pattern",
-            "minItems": "min_length",
-            "maxItems": "max_length",
-        }
-        for source, target in mapping.items():
-            if source in schema and not isinstance(schema[source], bool):
-                arguments.append(f"{target}={schema[source]!r}")
+        for source in ("description", "title"):
+            if source in schema:
+                arguments.append(f"{source}={schema[source]!r}")
         return arguments
 
     def _render_enum(self, name: str, schema: Mapping[str, Any]) -> str:
@@ -265,29 +292,33 @@ class OpenAPIModelGenerator:
             return self._render_root_model(name, schema)
 
         properties, required, additional = self._flatten_object(schema)
+        if not properties and isinstance(additional, Mapping):
+            return self._render_root_model(name, {"type": "object", "additionalProperties": additional})
+
         self.model_names.append(name)
         lines = [f"class {name}(BaseModel):"]
+        extra_mode = "forbid" if additional is False else "allow"
+        lines.append(f"    model_config = {{'extra': {extra_mode!r}, 'populate_by_name': True}}")
         if not properties:
-            if additional is not False:
-                lines.append("    model_config = {'extra': 'allow'}")
-            else:
-                lines.append("    pass")
             return "\n".join(lines)
+
+        if isinstance(additional, Mapping):
+            lines.append(
+                f"    __pydantic_extra__: dict[str, {self._type_for(additional)}] = Field(init=False)"
+            )
 
         for raw_field, field_schema in properties.items():
             if not isinstance(field_schema, Mapping):
                 raise OpenAPIGenerationError(f"property {raw_name}.{raw_field} must be an object")
             field_name, alias = _field_name(str(raw_field))
             annotation = self._type_for(field_schema)
-            is_required = raw_field in required and "default" not in field_schema
+            is_required = raw_field in required
             if not is_required and "None" not in annotation:
                 annotation = f"{annotation} | None"
             default = "..." if is_required else repr(field_schema.get("default", None))
             arguments = self._field_arguments(field_schema, alias)
             field_call = ", ".join([default, *arguments])
             lines.append(f"    {field_name}: {annotation} = Field({field_call})")
-        if additional is not False:
-            lines.append("\n    model_config = {'extra': 'allow'}")
         return "\n".join(lines)
 
     def render(self) -> str:
@@ -309,7 +340,7 @@ class OpenAPIModelGenerator:
             import_lines.append(f"from datetime import {names}")
         if "Enum" in self.imports:
             import_lines.append("from enum import Enum")
-        typing_names = sorted({"Any", "Literal"} & self.imports)
+        typing_names = sorted({"Annotated", "Any", "Literal"} & self.imports)
         if typing_names:
             import_lines.append(f"from typing import {', '.join(typing_names)}")
         if "UUID" in self.imports:

--- a/src/dslmodel/generators/openapi_models.py
+++ b/src/dslmodel/generators/openapi_models.py
@@ -1,0 +1,360 @@
+"""Deterministic OpenAPI 3 schema to Pydantic v2 model generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from keyword import iskeyword
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+
+class OpenAPIGenerationError(ValueError):
+    """Raised when an OpenAPI document cannot be deterministically rendered."""
+
+
+_IDENTIFIER = re.compile(r"\W+")
+
+
+def _class_name(value: str) -> str:
+    parts = [part for part in _IDENTIFIER.split(value) if part]
+    name = "".join(part[:1].upper() + part[1:] for part in parts) or "GeneratedModel"
+    if name[0].isdigit():
+        name = f"Model{name}"
+    return name
+
+
+def _field_name(value: str) -> tuple[str, str | None]:
+    candidate = _IDENTIFIER.sub("_", value).strip("_") or "field"
+    if candidate[0].isdigit():
+        candidate = f"field_{candidate}"
+    if iskeyword(candidate):
+        candidate = f"{candidate}_"
+    return candidate, value if candidate != value else None
+
+
+def _enum_member(value: Any, index: int) -> str:
+    candidate = _IDENTIFIER.sub("_", str(value)).strip("_").upper()
+    if not candidate:
+        candidate = f"VALUE_{index}"
+    if candidate[0].isdigit():
+        candidate = f"VALUE_{candidate}"
+    if iskeyword(candidate.lower()):
+        candidate = f"VALUE_{candidate}"
+    return candidate
+
+
+@dataclass(slots=True)
+class OpenAPIModelGenerator:
+    """Render every component schema in one OpenAPI document."""
+
+    document: Mapping[str, Any]
+    imports: set[str] = field(default_factory=set)
+    model_names: list[str] = field(default_factory=list)
+
+    @property
+    def schemas(self) -> Mapping[str, Mapping[str, Any]]:
+        schemas = self.document.get("components", {}).get("schemas", {})
+        if not isinstance(schemas, Mapping) or not schemas:
+            raise OpenAPIGenerationError("OpenAPI document has no components.schemas")
+        invalid = [name for name, schema in schemas.items() if not isinstance(schema, Mapping)]
+        if invalid:
+            raise OpenAPIGenerationError(f"schemas must be objects: {', '.join(map(str, invalid))}")
+        return schemas  # type: ignore[return-value]
+
+    def _resolve_ref(self, ref: str) -> tuple[str, Mapping[str, Any]]:
+        prefix = "#/components/schemas/"
+        if not ref.startswith(prefix):
+            raise OpenAPIGenerationError(f"unsupported external reference: {ref}")
+        raw_name = ref.removeprefix(prefix)
+        try:
+            schema = self.schemas[raw_name]
+        except KeyError as exc:
+            raise OpenAPIGenerationError(f"unresolved schema reference: {ref}") from exc
+        return _class_name(raw_name), schema
+
+    def _flatten_object(
+        self,
+        schema: Mapping[str, Any],
+        *,
+        seen_refs: frozenset[str] = frozenset(),
+    ) -> tuple[dict[str, Any], set[str], Any]:
+        properties: dict[str, Any] = {}
+        required: set[str] = set()
+        additional: Any = schema.get("additionalProperties", False)
+
+        ref = schema.get("$ref")
+        if isinstance(ref, str):
+            if ref in seen_refs:
+                return properties, required, additional
+            _, resolved = self._resolve_ref(ref)
+            return self._flatten_object(resolved, seen_refs=seen_refs | {ref})
+
+        for part in schema.get("allOf", []) or []:
+            if not isinstance(part, Mapping):
+                raise OpenAPIGenerationError("allOf entries must be schema objects")
+            part_properties, part_required, part_additional = self._flatten_object(
+                part,
+                seen_refs=seen_refs,
+            )
+            properties.update(part_properties)
+            required.update(part_required)
+            if part_additional is not False:
+                additional = part_additional
+
+        direct_properties = schema.get("properties", {}) or {}
+        if not isinstance(direct_properties, Mapping):
+            raise OpenAPIGenerationError("schema properties must be an object")
+        properties.update(direct_properties)
+        required.update(str(name) for name in (schema.get("required", []) or []))
+        return properties, required, additional
+
+    def _union(self, schemas: Sequence[Any]) -> str:
+        members = []
+        for item in schemas:
+            if not isinstance(item, Mapping):
+                raise OpenAPIGenerationError("union entries must be schema objects")
+            rendered = self._type_for(item)
+            if rendered not in members:
+                members.append(rendered)
+        if not members:
+            self.imports.add("Any")
+            return "Any"
+        if len(members) == 1:
+            return members[0]
+        return " | ".join(members)
+
+    def _type_for(self, schema: Mapping[str, Any]) -> str:
+        ref = schema.get("$ref")
+        if isinstance(ref, str):
+            result, _ = self._resolve_ref(ref)
+        elif schema.get("oneOf"):
+            result = self._union(schema["oneOf"])
+        elif schema.get("anyOf"):
+            result = self._union(schema["anyOf"])
+        elif schema.get("allOf"):
+            flattened, _, additional = self._flatten_object(schema)
+            if flattened:
+                self.imports.add("Any")
+                result = "dict[str, Any]"
+            elif isinstance(additional, Mapping):
+                result = f"dict[str, {self._type_for(additional)}]"
+            else:
+                self.imports.add("Any")
+                result = "dict[str, Any]"
+        elif "enum" in schema:
+            values = schema.get("enum") or []
+            self.imports.add("Literal")
+            result = f"Literal[{', '.join(repr(value) for value in values)}]"
+        else:
+            schema_type = schema.get("type")
+            if isinstance(schema_type, list):
+                members = [
+                    self._type_for({**schema, "type": member})
+                    for member in schema_type
+                    if member != "null"
+                ]
+                if not members:
+                    return "None"
+                result = " | ".join(dict.fromkeys(members))
+                if "null" in schema_type and "None" not in result:
+                    result = f"{result} | None"
+                return result
+
+            if schema_type == "string" or schema_type is None:
+                fmt = schema.get("format")
+                if fmt == "date-time":
+                    self.imports.add("datetime")
+                    result = "datetime"
+                elif fmt == "date":
+                    self.imports.add("date")
+                    result = "date"
+                elif fmt == "time":
+                    self.imports.add("time")
+                    result = "time"
+                elif fmt == "uuid":
+                    self.imports.add("UUID")
+                    result = "UUID"
+                elif schema_type is None:
+                    self.imports.add("Any")
+                    result = "Any"
+                else:
+                    result = "str"
+            elif schema_type == "integer":
+                result = "int"
+            elif schema_type == "number":
+                result = "float"
+            elif schema_type == "boolean":
+                result = "bool"
+            elif schema_type == "array":
+                items = schema.get("items", {})
+                if not isinstance(items, Mapping):
+                    raise OpenAPIGenerationError("array items must be a schema object")
+                result = f"list[{self._type_for(items)}]"
+            elif schema_type == "object":
+                additional = schema.get("additionalProperties")
+                if isinstance(additional, Mapping):
+                    result = f"dict[str, {self._type_for(additional)}]"
+                else:
+                    self.imports.add("Any")
+                    result = "dict[str, Any]"
+            elif schema_type == "null":
+                result = "None"
+            else:
+                raise OpenAPIGenerationError(f"unsupported schema type: {schema_type!r}")
+
+        if schema.get("nullable") and "None" not in result:
+            result = f"{result} | None"
+        return result
+
+    @staticmethod
+    def _field_arguments(schema: Mapping[str, Any], alias: str | None) -> list[str]:
+        arguments: list[str] = []
+        if alias:
+            arguments.append(f"alias={alias!r}")
+        mapping = {
+            "description": "description",
+            "title": "title",
+            "minimum": "ge",
+            "exclusiveMinimum": "gt",
+            "maximum": "le",
+            "exclusiveMaximum": "lt",
+            "minLength": "min_length",
+            "maxLength": "max_length",
+            "pattern": "pattern",
+            "minItems": "min_length",
+            "maxItems": "max_length",
+        }
+        for source, target in mapping.items():
+            if source in schema and not isinstance(schema[source], bool):
+                arguments.append(f"{target}={schema[source]!r}")
+        return arguments
+
+    def _render_enum(self, name: str, schema: Mapping[str, Any]) -> str:
+        self.imports.add("Enum")
+        values = list(schema.get("enum") or [])
+        if not values:
+            raise OpenAPIGenerationError(f"enum {name} has no values")
+        base = "str, Enum" if all(isinstance(value, str) for value in values) else "Enum"
+        lines = [f"class {name}({base}):"]
+        used: set[str] = set()
+        for index, value in enumerate(values, start=1):
+            member = _enum_member(value, index)
+            while member in used:
+                member = f"{member}_{index}"
+            used.add(member)
+            lines.append(f"    {member} = {value!r}")
+        return "\n".join(lines)
+
+    def _render_root_model(self, name: str, schema: Mapping[str, Any]) -> str:
+        self.imports.add("RootModel")
+        root_type = self._type_for(schema)
+        self.model_names.append(name)
+        return f"class {name}(RootModel[{root_type}]):\n    pass"
+
+    def _render_model(self, raw_name: str, schema: Mapping[str, Any]) -> str:
+        name = _class_name(raw_name)
+        if "enum" in schema and not schema.get("properties"):
+            return self._render_enum(name, schema)
+
+        schema_type = schema.get("type")
+        if schema_type not in (None, "object") and not schema.get("allOf"):
+            return self._render_root_model(name, schema)
+
+        properties, required, additional = self._flatten_object(schema)
+        self.model_names.append(name)
+        lines = [f"class {name}(BaseModel):"]
+        if not properties:
+            if additional is not False:
+                lines.append("    model_config = {'extra': 'allow'}")
+            else:
+                lines.append("    pass")
+            return "\n".join(lines)
+
+        for raw_field, field_schema in properties.items():
+            if not isinstance(field_schema, Mapping):
+                raise OpenAPIGenerationError(f"property {raw_name}.{raw_field} must be an object")
+            field_name, alias = _field_name(str(raw_field))
+            annotation = self._type_for(field_schema)
+            is_required = raw_field in required and "default" not in field_schema
+            if not is_required and "None" not in annotation:
+                annotation = f"{annotation} | None"
+            default = "..." if is_required else repr(field_schema.get("default", None))
+            arguments = self._field_arguments(field_schema, alias)
+            field_call = ", ".join([default, *arguments])
+            lines.append(f"    {field_name}: {annotation} = Field({field_call})")
+        if additional is not False:
+            lines.append("\n    model_config = {'extra': 'allow'}")
+        return "\n".join(lines)
+
+    def render(self) -> str:
+        """Return stable Python source for all component schemas."""
+
+        self.imports.clear()
+        self.model_names.clear()
+        class_names = [_class_name(str(name)) for name in self.schemas]
+        duplicates = sorted({name for name in class_names if class_names.count(name) > 1})
+        if duplicates:
+            raise OpenAPIGenerationError(
+                f"schema names collapse to duplicate Python identifiers: {', '.join(duplicates)}"
+            )
+        rendered = [self._render_model(str(name), schema) for name, schema in self.schemas.items()]
+
+        import_lines = ["from __future__ import annotations", ""]
+        if {"date", "datetime", "time"} & self.imports:
+            names = ", ".join(sorted({"date", "datetime", "time"} & self.imports))
+            import_lines.append(f"from datetime import {names}")
+        if "Enum" in self.imports:
+            import_lines.append("from enum import Enum")
+        typing_names = sorted({"Any", "Literal"} & self.imports)
+        if typing_names:
+            import_lines.append(f"from typing import {', '.join(typing_names)}")
+        if "UUID" in self.imports:
+            import_lines.append("from uuid import UUID")
+
+        pydantic_names = ["BaseModel", "Field"]
+        if "RootModel" in self.imports:
+            pydantic_names.append("RootModel")
+        import_lines.append(f"from pydantic import {', '.join(pydantic_names)}")
+        import_lines.append("")
+
+        body = "\n\n\n".join(rendered)
+        rebuild = ""
+        if self.model_names:
+            names = ", ".join(self.model_names)
+            rebuild = (
+                "\n\n\n# Resolve forward and circular references after every model exists.\n"
+                f"for _model in ({names},):\n"
+                "    _model.model_rebuild()\n"
+                "del _model\n"
+            )
+        return "\n".join(import_lines) + body + rebuild
+
+
+def load_openapi(path: Path) -> Mapping[str, Any]:
+    """Load an OpenAPI JSON or YAML document."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise OpenAPIGenerationError(f"cannot read {path}: {exc}") from exc
+    try:
+        document = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        raise OpenAPIGenerationError(f"invalid OpenAPI document {path}: {exc}") from exc
+    if not isinstance(document, Mapping):
+        raise OpenAPIGenerationError("OpenAPI document root must be an object")
+    return document
+
+
+def generate_openapi_models(openapi_file: Path, output_file: Path) -> Path:
+    """Generate a deterministic Pydantic module and return its path."""
+
+    document = load_openapi(openapi_file)
+    source = OpenAPIModelGenerator(document).render()
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(source, encoding="utf-8")
+    return output_file

--- a/src/dslmodel/selftest.py
+++ b/src/dslmodel/selftest.py
@@ -1,0 +1,172 @@
+"""Dependency-closed 80/20 execution verifier for DSLModel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import importlib.util
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import ModuleType
+from typing import Callable
+
+import typer
+
+from dslmodel.capabilities import (
+    CapabilityRegistry,
+    CapabilitySpec,
+    CapabilityStanding,
+    artifact_receipt,
+    verify_artifact_receipt,
+)
+from dslmodel.generators.openapi_models import generate_openapi_models
+
+
+@dataclass(frozen=True, slots=True)
+class SelfTestReceipt:
+    name: str
+    standing: CapabilityStanding
+    evidence: str
+    exception_type: str | None = None
+
+    @property
+    def receipt_id(self) -> str:
+        payload = json.dumps(
+            {
+                "name": self.name,
+                "standing": self.standing.value,
+                "evidence": self.evidence,
+                "exception_type": self.exception_type,
+            },
+            sort_keys=True,
+        )
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "name": self.name,
+            "standing": self.standing.value,
+            "evidence": self.evidence,
+            "exception_type": self.exception_type,
+            "receipt_id": self.receipt_id,
+        }
+
+
+def _check_openapi_roundtrip() -> str:
+    with TemporaryDirectory(prefix="dslmodel-selftest-") as temp:
+        root = Path(temp)
+        source = root / "openapi.yaml"
+        output = root / "models.py"
+        source.write_text(
+            """
+openapi: 3.1.0
+info: {title: selftest, version: '1'}
+components:
+  schemas:
+    Pet:
+      type: object
+      additionalProperties: false
+      required: [display-name]
+      properties:
+        display-name: {type: string, minLength: 1}
+        age: {type: integer, minimum: 0}
+""".strip(),
+            encoding="utf-8",
+        )
+        generate_openapi_models(source, output)
+        spec = importlib.util.spec_from_file_location("dslmodel_selftest_models", output)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("generated module could not be loaded")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        pet = module.Pet.model_validate({"display-name": "Mark", "age": 7})
+        if pet.model_dump(by_alias=True) != {"display-name": "Mark", "age": 7}:
+            raise AssertionError("generated model did not preserve aliases and values")
+        try:
+            module.Pet.model_validate({"display-name": "Mark", "unexpected": True})
+        except Exception:
+            pass
+        else:
+            raise AssertionError("additionalProperties=false was not enforced")
+        compile(output.read_text(encoding="utf-8"), str(output), "exec")
+        return "generated, imported, validated, and rejected forbidden properties"
+
+
+def _check_capability_execution() -> str:
+    module = ModuleType("dslmodel_selftest_capability")
+    module.app = typer.Typer()
+
+    @module.app.command("ping")
+    def ping() -> None:
+        typer.echo("pong")
+
+    registry = CapabilityRegistry(importer=lambda _: module)
+    receipt = registry.mount(
+        typer.Typer(),
+        CapabilitySpec(
+            "selftest-capability",
+            "dslmodel.selftest.capability",
+            "selftest",
+            required=True,
+            verifier_args=(),
+        ),
+    )
+    if receipt.standing is not CapabilityStanding.ALIVE or not receipt.executed or receipt.exit_code != 0:
+        raise AssertionError(receipt.as_dict())
+    return f"mounted and executed verifier receipt {receipt.receipt_id[:12]}"
+
+
+def _check_artifact_receipt() -> str:
+    with TemporaryDirectory(prefix="dslmodel-receipt-") as temp:
+        artifact = Path(temp) / "artifact.txt"
+        artifact.write_text("dslmodel-alive\n", encoding="utf-8")
+        receipt = artifact_receipt(artifact)
+        if not verify_artifact_receipt(artifact, str(receipt["digest"])):
+            raise AssertionError("receipt replay failed")
+        artifact.write_text("mutated\n", encoding="utf-8")
+        if verify_artifact_receipt(artifact, str(receipt["digest"])):
+            raise AssertionError("receipt did not detect artifact mutation")
+        return f"created, replayed, and falsified receipt {str(receipt['receipt_id'])[:12]}"
+
+
+_CHECKS: tuple[tuple[str, Callable[[], str]], ...] = (
+    ("openapi-roundtrip", _check_openapi_roundtrip),
+    ("capability-execution", _check_capability_execution),
+    ("artifact-receipt", _check_artifact_receipt),
+)
+
+
+def run_selftests() -> dict[str, object]:
+    """Execute the admitted 80/20 capability pack and return receipts."""
+
+    receipts: list[SelfTestReceipt] = []
+    for name, check in _CHECKS:
+        try:
+            evidence = check()
+        except Exception as exc:
+            receipts.append(
+                SelfTestReceipt(
+                    name=name,
+                    standing=CapabilityStanding.BUILD_BROKEN,
+                    evidence=str(exc),
+                    exception_type=type(exc).__name__,
+                )
+            )
+        else:
+            receipts.append(
+                SelfTestReceipt(
+                    name=name,
+                    standing=CapabilityStanding.ALIVE,
+                    evidence=evidence,
+                )
+            )
+    standing = (
+        CapabilityStanding.ALIVE.value
+        if receipts and all(item.standing is CapabilityStanding.ALIVE for item in receipts)
+        else CapabilityStanding.BUILD_BROKEN.value
+    )
+    return {
+        "standing": standing,
+        "checks": [item.as_dict() for item in receipts],
+    }

--- a/tests/generators/test_openapi_models.py
+++ b/tests/generators/test_openapi_models.py
@@ -141,3 +141,82 @@ def test_colliding_python_class_names_are_refused() -> None:
     }
     with pytest.raises(OpenAPIGenerationError, match="duplicate Python identifiers"):
         OpenAPIModelGenerator(document).render()
+
+
+def test_additional_properties_semantics_are_preserved() -> None:
+    document = {
+        "components": {
+            "schemas": {
+                "OpenObject": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+                "ClosedObject": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"name": {"type": "string"}},
+                },
+                "Counters": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer", "minimum": 0},
+                },
+            }
+        }
+    }
+    namespace: dict = {}
+    exec(compile(OpenAPIModelGenerator(document).render(), "extra_models.py", "exec"), namespace)
+
+    assert namespace["OpenObject"](name="x", extra=1).model_extra == {"extra": 1}
+    with pytest.raises(ValidationError):
+        namespace["ClosedObject"](name="x", extra=1)
+    assert namespace["Counters"]({"ok": 1}).root == {"ok": 1}
+    with pytest.raises(ValidationError):
+        namespace["Counters"]({"bad": -1})
+
+
+def test_required_property_with_default_remains_required() -> None:
+    document = {
+        "components": {
+            "schemas": {
+                "RequiredDefault": {
+                    "type": "object",
+                    "required": ["mode"],
+                    "properties": {"mode": {"type": "string", "default": "safe"}},
+                }
+            }
+        }
+    }
+    namespace: dict = {}
+    exec(compile(OpenAPIModelGenerator(document).render(), "required_models.py", "exec"), namespace)
+    with pytest.raises(ValidationError):
+        namespace["RequiredDefault"]()
+    assert namespace["RequiredDefault"](mode="safe").mode == "safe"
+
+
+def test_openapi_30_boolean_exclusive_bounds() -> None:
+    document = {
+        "components": {
+            "schemas": {
+                "Range": {
+                    "type": "object",
+                    "required": ["value"],
+                    "properties": {
+                        "value": {
+                            "type": "number",
+                            "minimum": 0,
+                            "exclusiveMinimum": True,
+                            "maximum": 10,
+                            "exclusiveMaximum": True,
+                        }
+                    },
+                }
+            }
+        }
+    }
+    namespace: dict = {}
+    exec(compile(OpenAPIModelGenerator(document).render(), "range_models.py", "exec"), namespace)
+    assert namespace["Range"](value=5).value == 5
+    with pytest.raises(ValidationError):
+        namespace["Range"](value=0)
+    with pytest.raises(ValidationError):
+        namespace["Range"](value=10)

--- a/tests/generators/test_openapi_models.py
+++ b/tests/generators/test_openapi_models.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from dslmodel.generators.openapi_models import (
+    OpenAPIGenerationError,
+    OpenAPIModelGenerator,
+    generate_openapi_models,
+)
+
+
+def sample_document() -> dict:
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "test", "version": "1"},
+        "components": {
+            "schemas": {
+                "Status": {"type": "string", "enum": ["ready", "blocked"]},
+                "Pet": {
+                    "type": "object",
+                    "required": ["name", "status"],
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1},
+                        "status": {"$ref": "#/components/schemas/Status"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "class": {"type": "string", "description": "reserved alias"},
+                    },
+                },
+                "OwnedPet": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/Pet"},
+                        {
+                            "type": "object",
+                            "required": ["owner_id"],
+                            "properties": {
+                                "owner_id": {"type": "string", "format": "uuid"}
+                            },
+                        },
+                    ]
+                },
+                "Node": {
+                    "type": "object",
+                    "required": ["value"],
+                    "properties": {
+                        "value": {"type": "string"},
+                        "next": {"$ref": "#/components/schemas/Node", "nullable": True},
+                    },
+                },
+            }
+        },
+    }
+
+
+def test_generator_renders_all_schemas_and_executes() -> None:
+    source = OpenAPIModelGenerator(sample_document()).render()
+    namespace: dict = {}
+    exec(compile(source, "generated_models.py", "exec"), namespace)
+
+    Status = namespace["Status"]
+    Pet = namespace["Pet"]
+    OwnedPet = namespace["OwnedPet"]
+    Node = namespace["Node"]
+
+    pet = Pet(name="Mark", status=Status.READY, tags=["dog"], **{"class": "dachshund"})
+    assert pet.class_ == "dachshund"
+    assert pet.model_dump(by_alias=True)["class"] == "dachshund"
+
+    owned = OwnedPet(
+        name="Mark",
+        status="ready",
+        owner_id="12345678-1234-5678-1234-567812345678",
+    )
+    assert str(owned.owner_id) == "12345678-1234-5678-1234-567812345678"
+
+    node = Node(value="root", next={"value": "leaf"})
+    assert node.next.value == "leaf"
+
+    with pytest.raises(ValidationError):
+        Pet(name="", status="ready")
+
+
+def test_generation_is_deterministic() -> None:
+    first = OpenAPIModelGenerator(sample_document()).render()
+    second = OpenAPIModelGenerator(sample_document()).render()
+    assert first == second
+
+
+def test_external_refs_are_refused() -> None:
+    document = {
+        "components": {
+            "schemas": {
+                "Broken": {
+                    "type": "object",
+                    "properties": {"value": {"$ref": "https://example.com/schema.json"}},
+                }
+            }
+        }
+    }
+    with pytest.raises(OpenAPIGenerationError, match="external reference"):
+        OpenAPIModelGenerator(document).render()
+
+
+def test_generate_openapi_models_writes_output(tmp_path: Path) -> None:
+    input_file = tmp_path / "openapi.json"
+    output_file = tmp_path / "models.py"
+    import json
+
+    input_file.write_text(json.dumps(sample_document()), encoding="utf-8")
+    result = generate_openapi_models(input_file, output_file)
+
+    assert result == output_file
+    assert output_file.read_text(encoding="utf-8").startswith("from __future__ import annotations")
+
+
+def test_required_nullable_reference_is_preserved() -> None:
+    document = sample_document()
+    document["components"]["schemas"]["RequiredNullable"] = {
+        "type": "object",
+        "required": ["pet"],
+        "properties": {
+            "pet": {"$ref": "#/components/schemas/Pet", "nullable": True}
+        },
+    }
+    source = OpenAPIModelGenerator(document).render()
+    namespace: dict = {}
+    exec(compile(source, "nullable_models.py", "exec"), namespace)
+    assert namespace["RequiredNullable"](pet=None).pet is None
+
+
+def test_colliding_python_class_names_are_refused() -> None:
+    document = {
+        "components": {
+            "schemas": {
+                "foo-bar": {"type": "object"},
+                "foo bar": {"type": "object"},
+            }
+        }
+    }
+    with pytest.raises(OpenAPIGenerationError, match="duplicate Python identifiers"):
+        OpenAPIModelGenerator(document).render()

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -74,5 +74,23 @@ def test_required_failure_controls_registry_standing() -> None:
     registry.probe(CapabilitySpec("required", "example.required", "required", required=True))
 
     report = registry.report()
-    assert report["standing"] == "PARTIAL_ALIVE"
+    assert report["standing"] == "UNSUPPORTED"
     assert report["required_failures"][0]["name"] == "required"
+
+
+def test_registry_aggregate_never_crowns_partial_surface() -> None:
+    healthy = ModuleType("healthy")
+    healthy.app = typer.Typer()
+
+    def importer(name: str) -> ModuleType:
+        if name == "example.healthy":
+            return healthy
+        error = ModuleNotFoundError("No module named 'missing_dep'")
+        error.name = "missing_dep"
+        raise error
+
+    registry = CapabilityRegistry(importer=importer)
+    registry.mount(typer.Typer(), CapabilitySpec("healthy", "example.healthy", "healthy"))
+    registry.probe(CapabilitySpec("missing", "example.missing", "missing"))
+
+    assert registry.report()["standing"] == "PARTIAL_ALIVE"

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import ModuleType
 
 import typer
@@ -6,12 +7,24 @@ from dslmodel.capabilities import (
     CapabilityRegistry,
     CapabilitySpec,
     CapabilityStanding,
+    artifact_receipt,
+    verify_artifact_receipt,
 )
 
 
+def _healthy_module() -> ModuleType:
+    module = ModuleType("healthy")
+    module.app = typer.Typer()
+
+    @module.app.command("ping")
+    def ping() -> None:
+        typer.echo("pong")
+
+    return module
+
+
 def test_capabilities_are_admitted_independently() -> None:
-    healthy = ModuleType("healthy")
-    healthy.app = typer.Typer()
+    healthy = _healthy_module()
 
     def importer(name: str) -> ModuleType:
         if name == "example.healthy":
@@ -28,14 +41,50 @@ def test_capabilities_are_admitted_independently() -> None:
     )
     admitted = registry.mount(
         parent,
-        CapabilitySpec("healthy", "example.healthy", "healthy capability"),
+        CapabilitySpec(
+            "healthy",
+            "example.healthy",
+            "healthy capability",
+            verifier_args=(),
+        ),
     )
 
     assert missing.standing is CapabilityStanding.UNSUPPORTED
     assert not missing.mounted
     assert admitted.standing is CapabilityStanding.ALIVE
     assert admitted.mounted
+    assert admitted.executed
+    assert admitted.exit_code == 0
     assert [group.name for group in parent.registered_groups] == ["healthy"]
+
+
+def test_import_without_execution_is_only_partial_alive() -> None:
+    registry = CapabilityRegistry(importer=lambda _: _healthy_module())
+    receipt = registry.probe(CapabilitySpec("healthy", "example.healthy", "healthy"))
+
+    assert receipt.standing is CapabilityStanding.PARTIAL_ALIVE
+    assert receipt.imported
+    assert not receipt.mounted
+    assert not receipt.executed
+
+
+def test_failing_verifier_is_build_broken() -> None:
+    module = ModuleType("broken")
+    module.app = typer.Typer()
+
+    @module.app.command("fail")
+    def fail() -> None:
+        raise typer.Exit(7)
+
+    registry = CapabilityRegistry(importer=lambda _: module)
+    receipt = registry.mount(
+        typer.Typer(),
+        CapabilitySpec("broken", "example.broken", "broken", verifier_args=()),
+    )
+
+    assert receipt.standing is CapabilityStanding.BUILD_BROKEN
+    assert receipt.executed
+    assert receipt.exit_code == 7
 
 
 def test_internal_missing_module_is_build_broken() -> None:
@@ -52,12 +101,11 @@ def test_internal_missing_module_is_build_broken() -> None:
 
 
 def test_receipt_identity_is_deterministic() -> None:
-    module = ModuleType("example")
-    module.app = typer.Typer()
+    module = _healthy_module()
     registry = CapabilityRegistry(importer=lambda _: module)
-    spec = CapabilitySpec("example", "example.module", "example")
+    spec = CapabilitySpec("example", "example.module", "example", verifier_args=())
 
-    first = registry.probe(spec)
+    first = registry.mount(typer.Typer(), spec)
     second = registry.probe(spec)
 
     assert first.receipt_id == second.receipt_id
@@ -79,8 +127,7 @@ def test_required_failure_controls_registry_standing() -> None:
 
 
 def test_registry_aggregate_never_crowns_partial_surface() -> None:
-    healthy = ModuleType("healthy")
-    healthy.app = typer.Typer()
+    healthy = _healthy_module()
 
     def importer(name: str) -> ModuleType:
         if name == "example.healthy":
@@ -90,7 +137,33 @@ def test_registry_aggregate_never_crowns_partial_surface() -> None:
         raise error
 
     registry = CapabilityRegistry(importer=importer)
-    registry.mount(typer.Typer(), CapabilitySpec("healthy", "example.healthy", "healthy"))
+    registry.mount(
+        typer.Typer(),
+        CapabilitySpec("healthy", "example.healthy", "healthy", verifier_args=()),
+    )
     registry.probe(CapabilitySpec("missing", "example.missing", "missing"))
 
     assert registry.report()["standing"] == "PARTIAL_ALIVE"
+
+
+def test_artifact_receipt_replays_and_detects_drift(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("alive\n", encoding="utf-8")
+
+    first = artifact_receipt(artifact)
+    second = artifact_receipt(artifact)
+    assert first == second
+    assert verify_artifact_receipt(artifact, str(first["digest"]))
+
+    artifact.write_text("changed\n", encoding="utf-8")
+    assert not verify_artifact_receipt(artifact, str(first["digest"]))
+
+
+def test_artifact_identity_is_transport_independent(tmp_path: Path) -> None:
+    first = tmp_path / "first.txt"
+    second = tmp_path / "nested" / "second.txt"
+    second.parent.mkdir()
+    first.write_text("same bytes\n", encoding="utf-8")
+    second.write_text("same bytes\n", encoding="utf-8")
+
+    assert artifact_receipt(first)["receipt_id"] == artifact_receipt(second)["receipt_id"]

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,78 @@
+from types import ModuleType
+
+import typer
+
+from dslmodel.capabilities import (
+    CapabilityRegistry,
+    CapabilitySpec,
+    CapabilityStanding,
+)
+
+
+def test_capabilities_are_admitted_independently() -> None:
+    healthy = ModuleType("healthy")
+    healthy.app = typer.Typer()
+
+    def importer(name: str) -> ModuleType:
+        if name == "example.healthy":
+            return healthy
+        error = ModuleNotFoundError("No module named 'optional_dependency'")
+        error.name = "optional_dependency"
+        raise error
+
+    registry = CapabilityRegistry(importer=importer)
+    parent = typer.Typer()
+    missing = registry.mount(
+        parent,
+        CapabilitySpec("missing", "example.missing", "missing capability"),
+    )
+    admitted = registry.mount(
+        parent,
+        CapabilitySpec("healthy", "example.healthy", "healthy capability"),
+    )
+
+    assert missing.standing is CapabilityStanding.UNSUPPORTED
+    assert not missing.mounted
+    assert admitted.standing is CapabilityStanding.ALIVE
+    assert admitted.mounted
+    assert [group.name for group in parent.registered_groups] == ["healthy"]
+
+
+def test_internal_missing_module_is_build_broken() -> None:
+    def importer(name: str) -> ModuleType:
+        error = ModuleNotFoundError(f"No module named {name!r}")
+        error.name = name
+        raise error
+
+    registry = CapabilityRegistry(importer=importer)
+    receipt = registry.probe(CapabilitySpec("broken", "dslmodel.commands.broken", "broken"))
+
+    assert receipt.standing is CapabilityStanding.BUILD_BROKEN
+    assert receipt.missing_dependency == "dslmodel.commands.broken"
+
+
+def test_receipt_identity_is_deterministic() -> None:
+    module = ModuleType("example")
+    module.app = typer.Typer()
+    registry = CapabilityRegistry(importer=lambda _: module)
+    spec = CapabilitySpec("example", "example.module", "example")
+
+    first = registry.probe(spec)
+    second = registry.probe(spec)
+
+    assert first.receipt_id == second.receipt_id
+    assert len(first.receipt_id) == 64
+
+
+def test_required_failure_controls_registry_standing() -> None:
+    def importer(name: str) -> ModuleType:
+        error = ModuleNotFoundError("No module named 'missing_dep'")
+        error.name = "missing_dep"
+        raise error
+
+    registry = CapabilityRegistry(importer=importer)
+    registry.probe(CapabilitySpec("required", "example.required", "required", required=True))
+
+    report = registry.report()
+    assert report["standing"] == "PARTIAL_ALIVE"
+    assert report["required_failures"][0]["name"] == "required"

--- a/tests/test_cli_modernization.py
+++ b/tests/test_cli_modernization.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+from typer.testing import CliRunner
+
+
+runner = CliRunner()
+
+
+def test_package_import_has_no_dspy_side_effect() -> None:
+    sys.modules.pop("dslmodel.utils.dspy_tools", None)
+    import dslmodel
+
+    assert "dslmodel.utils.dspy_tools" not in sys.modules
+    assert "DSLModel" in dir(dslmodel)
+
+
+def test_root_help_survives_missing_optional_capabilities() -> None:
+    from dslmodel.cli import app
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "doctor" in result.output
+    assert "openapi" in result.output
+    assert "dsl" in result.output
+
+
+def test_root_doctor_emits_machine_readable_receipts() -> None:
+    from dslmodel.cli import app
+
+    result = runner.invoke(app, ["doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["standing"] in {"ALIVE", "PARTIAL_ALIVE"}
+    assert payload["capabilities"]
+    assert all(len(item["receipt_id"]) == 64 for item in payload["capabilities"])
+
+
+def test_consolidated_cli_has_real_grouped_surface() -> None:
+    from dslmodel.commands.consolidated_cli import app
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "core" in result.output
+    assert "advanced" in result.output
+    assert "status" in result.output
+
+    status = runner.invoke(app, ["status", "--json"])
+    assert status.exit_code == 0, status.output
+    payload = json.loads(status.output)
+    assert set(payload["groups"]) == {
+        "core",
+        "development",
+        "research",
+        "security",
+        "telemetry",
+        "validation",
+    }
+
+
+def test_openapi_cli_generates_executable_models(tmp_path: Path) -> None:
+    from dslmodel.cli import app
+
+    schema = tmp_path / "openapi.yaml"
+    output = tmp_path / "models.py"
+    schema.write_text(
+        """
+openapi: 3.1.0
+info: {title: test, version: '1'}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [name]
+      properties:
+        name: {type: string, minLength: 1}
+        age: {type: integer, minimum: 0}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["openapi", str(schema), "--output", str(output)])
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    compile(output.read_text(encoding="utf-8"), str(output), "exec")

--- a/tests/test_cli_modernization.py
+++ b/tests/test_cli_modernization.py
@@ -18,50 +18,71 @@ def test_package_import_has_no_dspy_side_effect() -> None:
     assert "DSLModel" in dir(dslmodel)
 
 
-def test_root_help_survives_missing_optional_capabilities() -> None:
+def test_root_help_contains_only_canonical_surface() -> None:
     from dslmodel.cli import app
 
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0, result.output
-    assert "doctor" in result.output
-    assert "openapi" in result.output
-    assert "dsl" in result.output
+    for command in ("doctor", "openapi", "receipt", "selftest", "dsl"):
+        assert command in result.output
+    for retired in ("ollama-auto", "weaver-loop", "evolve-legacy", "forge-dx"):
+        assert retired not in result.output
 
 
-def test_root_doctor_emits_machine_readable_receipts() -> None:
+def test_root_doctor_is_strictly_alive_and_execution_backed() -> None:
     from dslmodel.cli import app
 
-    result = runner.invoke(app, ["doctor", "--json"])
+    result = runner.invoke(app, ["doctor", "--json", "--strict"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert payload["standing"] in {"ALIVE", "PARTIAL_ALIVE"}
-    assert payload["capabilities"]
-    assert all(len(item["receipt_id"]) == 64 for item in payload["capabilities"])
+    assert payload["standing"] == "ALIVE"
+    capabilities = payload["capability_registry"]["capabilities"]
+    assert [item["name"] for item in capabilities] == ["dsl"]
+    assert capabilities[0]["standing"] == "ALIVE"
+    assert capabilities[0]["mounted"] is True
+    assert capabilities[0]["executed"] is True
+    assert capabilities[0]["exit_code"] == 0
+    assert all(item["standing"] == "ALIVE" for item in payload["semantic_checks"])
 
 
-def test_consolidated_cli_has_real_grouped_surface() -> None:
+def test_consolidated_cli_is_strictly_alive() -> None:
     from dslmodel.commands.consolidated_cli import app
 
-    result = runner.invoke(app, ["--help"])
-    assert result.exit_code == 0, result.output
-    assert "core" in result.output
-    assert "advanced" in result.output
-    assert "status" in result.output
+    help_result = runner.invoke(app, ["--help"])
+    assert help_result.exit_code == 0, help_result.output
+    for command in ("core", "evidence", "selftest", "status", "inventory"):
+        assert command in help_result.output
 
-    status = runner.invoke(app, ["status", "--json"])
+    status = runner.invoke(app, ["status", "--json", "--strict"])
     assert status.exit_code == 0, status.output
     payload = json.loads(status.output)
-    assert set(payload["groups"]) == {
-        "core",
-        "development",
-        "research",
-        "security",
-        "telemetry",
-        "validation",
+    assert payload["standing"] == "ALIVE"
+    assert payload["admitted_count"] == 5
+    assert payload["non_admitted_count"] >= 40
+    assert all(item["standing"] == "ALIVE" for item in payload["checks"])
+
+
+def test_inventory_preserves_retired_surface_without_admitting_it() -> None:
+    from dslmodel.commands.consolidated_cli import app
+
+    result = runner.invoke(app, ["inventory", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["standing"] == "ALIVE"
+    assert {item["name"] for item in payload["admitted"]} == {
+        "core.openapi",
+        "validate.selftest",
+        "evidence.receipt",
+        "system.status",
+        "system.inventory",
     }
+    retired = {item["name"]: item for item in payload["non_admitted"]}
+    assert retired["gen"]["disposition"] == "NOT_ADMITTED"
+    assert retired["pqc"]["disposition"] == "NOT_ADMITTED"
+    assert retired["forge-dx"]["replacement"].startswith("dsl core openapi")
 
 
-def test_openapi_cli_generates_executable_models(tmp_path: Path) -> None:
+def test_openapi_cli_generates_executable_models_and_receipt(tmp_path: Path) -> None:
     from dslmodel.cli import app
 
     schema = tmp_path / "openapi.yaml"
@@ -84,5 +105,26 @@ components:
 
     result = runner.invoke(app, ["openapi", str(schema), "--output", str(output)])
     assert result.exit_code == 0, result.output
+    assert "ALIVE" in result.output
+    assert "sha256=" in result.output
     assert output.exists()
     compile(output.read_text(encoding="utf-8"), str(output), "exec")
+
+
+def test_receipt_cli_replays_identity(tmp_path: Path) -> None:
+    from dslmodel.cli import app
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("receipt\n", encoding="utf-8")
+    created = runner.invoke(app, ["receipt", str(artifact), "--json"])
+    assert created.exit_code == 0, created.output
+    payload = json.loads(created.output)
+    assert payload["standing"] == "ALIVE"
+
+    replay = runner.invoke(app, ["receipt", str(artifact), "--expect", payload["digest"], "--json"])
+    assert replay.exit_code == 0, replay.output
+    assert json.loads(replay.output)["verified"] is True
+
+    refused = runner.invoke(app, ["receipt", str(artifact), "--expect", "0" * 64, "--json"])
+    assert refused.exit_code == 1
+    assert json.loads(refused.output)["standing"] == "BUILD_BROKEN"


### PR DESCRIPTION
## Identity

- Base: `main@4196bb8b79e5decbe6fad3b1a74d06fba15c318e`
- Head: `codex/errc-modernize-capabilities@399913d54f499d256a2f8c754b3511a2603a324d`
- Tree: `ab8b6a1455c415ced50f5f40e672fb63147d4645`
- Scope: 12 changed files; 25 commits ahead, 0 behind; exact merge base retained.

## Standing

**Canonical admitted product surface: `ALIVE`.**

`ALIVE` now requires observed verifier execution. Import or mount success alone is `PARTIAL_ALIVE`.

### Admitted 80/20 jobs

1. `core.openapi` — deterministic OpenAPI 3 → executable Pydantic v2 manufacture
2. `validate.selftest` — dependency-closed semantic self-play
3. `evidence.receipt` — deterministic artifact identity, replay, and drift falsification
4. `system.status` — strict machine-readable aggregate standing
5. `system.inventory` — admitted/non-admitted capability catalog

Forty historical aliases and experimental/external-runtime integrations remain recoverable in the repository but are explicitly `NOT_ADMITTED`; they do not pollute product standing or receive fabricated success/failure labels.

## ERRC closure

### Eliminate
- eager DSPy/text initialization and global warning suppression
- global import-failure coupling
- placeholder commands and duplicate root aliases
- LLM/network dependency for OpenAPI manufacture
- Node/devcontainer overhead in the canonical CI verifier

### Reduce
- advertised surface from roughly forty legacy commands to five high-value jobs
- optional-dependency blast radius
- CI to a dependency-closed Python 3.12 pack with a five-minute timeout

### Raise
- import/mount evidence → observed command execution
- deterministic capability and artifact receipts
- content identity independent of transport path
- strict crown commands and mutation falsifiers

### Create
- semantic self-test pack
- receipt/replay CLI
- reversible non-admitted inventory
- per-PR Actions concurrency fencing with stale-run cancellation

## Local exact-blob receipts

```text
python -m compileall -q src tests
exit 0 (1.73s)

PYTHONPATH=src pytest -q \
  tests/test_capabilities.py \
  tests/test_cli_modernization.py \
  tests/generators/test_openapi_models.py
25 passed in 0.57s

PYTHONPATH=src python -m dslmodel.cli doctor --json --strict
exit 0; standing=ALIVE

PYTHONPATH=src python -m dslmodel.cli dsl status --json --strict
exit 0; standing=ALIVE
```

Changed-surface coverage: **76% aggregate**; capability execution registry **87%**; semantic self-test **90%**; OpenAPI generator **74%**.

Two independent strict doctor replays are byte-identical. Published Git blob identities for the modified execution surfaces match the locally executed capsule.

## Hosted CI boundary

Exact-head run `31082832663` is queued with no runner and no executed steps. Repository history currently shows 16 PR runs queued, zero running, and zero completed. This is an Actions capacity/policy boundary, not a test failure. The workflow now cancels stale future heads per PR and runs only the dependency-closed five-minute verifier when a runner is assigned.

Ruff remains `UNKNOWN` because it is absent from the offline tool cache; no lint success is claimed.

No merge requested or performed.